### PR TITLE
feat: add target type enum

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/targets/CustomQueryTarget.java
+++ b/src/main/java/org/neo4j/importer/v1/targets/CustomQueryTarget.java
@@ -32,7 +32,7 @@ public class CustomQueryTarget extends Target {
             @JsonProperty(value = "source", required = true) String source,
             @JsonProperty("depends_on") List<String> dependencies,
             @JsonProperty(value = "query", required = true) String query) {
-        super(active, name, source, dependencies);
+        super(TargetType.QUERY, active, name, source, dependencies);
         this.query = query;
     }
 

--- a/src/main/java/org/neo4j/importer/v1/targets/NodeTarget.java
+++ b/src/main/java/org/neo4j/importer/v1/targets/NodeTarget.java
@@ -39,7 +39,7 @@ public class NodeTarget extends Target {
             @JsonProperty(value = "labels", required = true) List<String> labels,
             @JsonProperty(value = "properties", required = true) List<PropertyMapping> properties,
             @JsonProperty("schema") NodeSchema schema) {
-        super(active, name, source, dependencies);
+        super(TargetType.NODE, active, name, source, dependencies);
         this.writeMode = writeMode;
         this.sourceTransformations = sourceTransformations;
         this.labels = labels;

--- a/src/main/java/org/neo4j/importer/v1/targets/RelationshipTarget.java
+++ b/src/main/java/org/neo4j/importer/v1/targets/RelationshipTarget.java
@@ -47,7 +47,7 @@ public class RelationshipTarget extends Target {
             @JsonProperty("properties") List<PropertyMapping> properties,
             @JsonProperty("schema") RelationshipSchema schema) {
 
-        super(active, name, source, dependencies);
+        super(TargetType.RELATIONSHIP, active, name, source, dependencies);
         this.type = type;
         this.writeMode = writeMode;
         this.nodeMatchMode = nodeMatchMode;

--- a/src/main/java/org/neo4j/importer/v1/targets/Target.java
+++ b/src/main/java/org/neo4j/importer/v1/targets/Target.java
@@ -24,16 +24,22 @@ import java.util.Objects;
 public abstract class Target implements Comparable<Target>, Serializable {
 
     protected static final String DEFAULT_ACTIVE = "true";
+    private final TargetType targetType;
     private final boolean active;
     private final String name;
     private final String source;
     private final List<String> dependencies;
 
-    Target(Boolean active, String name, String source, List<String> dependencies) {
+    Target(TargetType targetType, Boolean active, String name, String source, List<String> dependencies) {
+        this.targetType = targetType;
         this.active = active != null ? active : Boolean.valueOf(DEFAULT_ACTIVE).booleanValue();
         this.name = name;
         this.source = source;
         this.dependencies = dependencies != null ? dependencies : Collections.emptyList();
+    }
+
+    public TargetType getTargetType() {
+        return targetType;
     }
 
     public boolean isActive() {
@@ -73,6 +79,7 @@ public abstract class Target implements Comparable<Target>, Serializable {
         if (o == null || getClass() != o.getClass()) return false;
         Target target = (Target) o;
         return active == target.active
+                && targetType == target.targetType
                 && Objects.equals(name, target.name)
                 && Objects.equals(source, target.source)
                 && Objects.equals(dependencies, target.dependencies);
@@ -80,15 +87,16 @@ public abstract class Target implements Comparable<Target>, Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(active, name, source, dependencies);
+        return Objects.hash(targetType, active, name, source, dependencies);
     }
 
     @Override
     public String toString() {
-        return "Target{" + "active="
+        return "Target{" + "targetType="
+                + targetType + ", active="
                 + active + ", name='"
                 + name + '\'' + ", source='"
-                + source + '\'' + ", dependencies='"
-                + dependencies + '\'' + '}';
+                + source + '\'' + ", dependencies="
+                + dependencies + '}';
     }
 }

--- a/src/main/java/org/neo4j/importer/v1/targets/TargetType.java
+++ b/src/main/java/org/neo4j/importer/v1/targets/TargetType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.targets;
+
+public enum TargetType {
+    NODE,
+    RELATIONSHIP,
+    QUERY
+}

--- a/src/test/java/org/neo4j/importer/v1/targets/TargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/targets/TargetTest.java
@@ -46,6 +46,7 @@ class TargetTest {
 
         var target = mapper.readValue(json, CustomQueryTarget.class);
 
+        assertThat(target.getTargetType()).isEqualTo(TargetType.QUERY);
         assertThat(target.getName()).isEqualTo("my-minimal-custom-query-target");
         assertThat(target.isActive()).isTrue();
         assertThat(target.getSource()).isEqualTo("a-source");
@@ -68,6 +69,7 @@ class TargetTest {
 
         var target = mapper.readValue(json, CustomQueryTarget.class);
 
+        assertThat(target.getTargetType()).isEqualTo(TargetType.QUERY);
         assertThat(target.getName()).isEqualTo("my-custom-query-target");
         assertThat(target.isActive()).isFalse();
         assertThat(target.getSource()).isEqualTo("a-source");
@@ -93,6 +95,7 @@ class TargetTest {
 
         var target = mapper.readValue(json, NodeTarget.class);
 
+        assertThat(target.getTargetType()).isEqualTo(TargetType.NODE);
         assertThat(target.getName()).isEqualTo("my-minimal-node-target");
         assertThat(target.isActive()).isTrue();
         assertThat(target.getSource()).isEqualTo("a-source");
@@ -171,6 +174,7 @@ class TargetTest {
 
         var target = mapper.readValue(json, NodeTarget.class);
 
+        assertThat(target.getTargetType()).isEqualTo(TargetType.NODE);
         assertThat(target.getName()).isEqualTo("my-node-target");
         assertThat(target.isActive()).isFalse();
         assertThat(target.getSource()).isEqualTo("a-source");
@@ -264,6 +268,7 @@ class TargetTest {
 
         var target = mapper.readValue(json, RelationshipTarget.class);
 
+        assertThat(target.getTargetType()).isEqualTo(TargetType.RELATIONSHIP);
         assertThat(target.getStartNodeReference()).isEqualTo("a-node-target");
         assertThat(target.getEndNodeReference()).isEqualTo("another-node-target");
     }
@@ -339,6 +344,7 @@ class TargetTest {
 
         var target = mapper.readValue(json, RelationshipTarget.class);
 
+        assertThat(target.getTargetType()).isEqualTo(TargetType.RELATIONSHIP);
         assertThat(target.getName()).isEqualTo("my-relationship-target");
         assertThat(target.isActive()).isFalse();
         assertThat(target.getSource()).isEqualTo("a-source");


### PR DESCRIPTION
Since we're stuck with JDK 11 as a baseline for now, we cannot use pattern matching on target types, so this is an alternative to avoid littering users with if-instance-of statements.