### PR TITLE
fix: admin-import command, move database name to start of command

### DIFF
--- a/src/test/java/org/neo4j/importer/v1/e2e/AdminImportIT.java
+++ b/src/test/java/org/neo4j/importer/v1/e2e/AdminImportIT.java
@@ -340,26 +340,24 @@ public class AdminImportIT {
         private static String[] importCommand(ImportSpecification importSpec, String database) {
             var command = new StringBuilder();
             command.append("neo4j-admin database import full ");
+            command.append(database);
             Targets targets = importSpec.getTargets();
             for (NodeTarget nodeTarget : targets.getNodes()) {
-                command.append("--nodes=");
+                command.append(" --nodes=");
                 command.append(String.join(":", nodeTarget.getLabels()));
                 command.append("=");
                 command.append("/import/%s".formatted(headerFileName(nodeTarget)));
                 command.append(",");
                 command.append("/import/%s".formatted(dataFileName(nodeTarget)));
-                command.append(" ");
             }
             for (RelationshipTarget relationshipTarget : targets.getRelationships()) {
-                command.append("--relationships=");
+                command.append(" --relationships=");
                 command.append(relationshipTarget.getType());
                 command.append("=");
                 command.append("/import/%s".formatted(headerFileName(relationshipTarget)));
                 command.append(",");
                 command.append("/import/%s".formatted(dataFileName(relationshipTarget)));
-                command.append(" ");
             }
-            command.append(database);
             return command.toString().split(" ");
         }
 


### PR DESCRIPTION
There appears to be a regression between Neo4j 5.18.1 and Neo4j 5.19 where the admin-import command ignores or incorrectly parses the database name.