### PR TITLE
feat: relax name uniqueness requirement

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDependencyCycleValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDependencyCycleValidator.java
@@ -50,7 +50,7 @@ public class NoDependencyCycleValidator implements SpecificationValidator {
     @Override
     public Set<Class<? extends SpecificationValidator>> requires() {
         return Set.of(
-                NoDuplicatedNameValidator.class,
+                NoDuplicatedTargetActionNameValidator.class,
                 NoDanglingDependsOnValidator.class,
                 NoDanglingNodeReferenceValidator.class,
                 NoDuplicatedDependencyValidator.class);

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedSourceNameValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedSourceNameValidator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import org.neo4j.importer.v1.sources.Source;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDuplicatedSourceNameValidator implements SpecificationValidator {
+    private static final String ERROR_CODE = "DUPL-004";
+
+    private final NameCounter nameCounter;
+
+    public NoDuplicatedSourceNameValidator() {
+        nameCounter = new NameCounter(ERROR_CODE);
+    }
+
+    @Override
+    public void visitSource(int index, Source source) {
+        nameCounter.track(source.getName(), String.format("$.sources[%d]", index));
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        return nameCounter.reportErrorsIfAny(builder);
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedTargetActionNameValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedTargetActionNameValidator.java
@@ -22,24 +22,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.neo4j.importer.v1.actions.Action;
-import org.neo4j.importer.v1.sources.Source;
 import org.neo4j.importer.v1.targets.CustomQueryTarget;
 import org.neo4j.importer.v1.targets.NodeTarget;
 import org.neo4j.importer.v1.targets.RelationshipTarget;
 import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
 import org.neo4j.importer.v1.validation.SpecificationValidator;
 
-public class NoDuplicatedNameValidator implements SpecificationValidator {
+public class NoDuplicatedTargetActionNameValidator implements SpecificationValidator {
+    private static final String ERROR_CODE = "DUPL-001";
 
     private final NameCounter nameCounter;
 
-    public NoDuplicatedNameValidator() {
-        nameCounter = new NameCounter();
-    }
-
-    @Override
-    public void visitSource(int index, Source source) {
-        nameCounter.track(source.getName(), String.format("$.sources[%d]", index));
+    public NoDuplicatedTargetActionNameValidator() {
+        nameCounter = new NameCounter(ERROR_CODE);
     }
 
     @Override
@@ -69,9 +64,13 @@ public class NoDuplicatedNameValidator implements SpecificationValidator {
 }
 
 class NameCounter {
-    private static final String ERROR_CODE = "DUPL-001";
 
     private final Map<String, List<String>> pathsUsingName = new LinkedHashMap<>();
+    private final String errorCode;
+
+    public NameCounter(String errorCode) {
+        this.errorCode = errorCode;
+    }
 
     public void track(String name, String path) {
         pathsUsingName.computeIfAbsent(name, (ignored) -> new ArrayList<>()).add(String.format("%s.name", path));
@@ -86,7 +85,7 @@ class NameCounter {
                     result.set(true);
                     builder.addError(
                             paths.get(0),
-                            ERROR_CODE,
+                            errorCode,
                             String.format(
                                     "Name \"%s\" is duplicated across the following paths: %s",
                                     entry.getKey(), String.join(", ", paths)));

--- a/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -1,4 +1,4 @@
-org.neo4j.importer.v1.validation.plugin.NoDuplicatedNameValidator
+org.neo4j.importer.v1.validation.plugin.NoDuplicatedTargetActionNameValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingSourceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingDependsOnValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingNodeReferenceValidator
@@ -8,3 +8,4 @@ org.neo4j.importer.v1.validation.plugin.NoInconsistentInlineSourceDataValidator
 org.neo4j.importer.v1.validation.plugin.AtLeastOneActiveTargetValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedDependencyValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingActiveNodeReferenceValidator
+org.neo4j.importer.v1.validation.plugin.NoDuplicatedSourceNameValidator


### PR DESCRIPTION
Sources and targets/actions can now share the same name, since that does not actually cause any problem in practice.

Relaxing this requirement reduces the risk of breaking existing legacy Dataflow specs.