### PR TITLE
ci: skip whitelist checks for dependabot

### DIFF
--- a/.teamcity/builds/WhiteListCheck.kt
+++ b/.teamcity/builds/WhiteListCheck.kt
@@ -24,17 +24,20 @@ class WhiteListCheck(id: String, name: String) :
               """
                 #!/bin/bash -eu
                 
-                token="%github-pull-request-token%"
+                BRANCH=%teamcity.pullRequest.source.branch%
+                if [[ "${'$'}BRANCH" =~ dependabot/.* ]]; then
+                  echo "Raised by dependabot, skipping the white list check"
+                  exit 0
+                fi
                 
                 echo "Checking committers on PR %teamcity.build.branch%"
+                TOKEN="%github-pull-request-token%"
                 
                 # process pull request
-                ./whitelist-check/bin/examine-pull-request $GITHUB_OWNER $GITHUB_REPOSITORY "${'$'}{token}" %teamcity.build.branch% whitelist-check/cla-database.csv
+                ./whitelist-check/bin/examine-pull-request $GITHUB_OWNER $GITHUB_REPOSITORY "${'$'}{TOKEN}" %teamcity.build.branch% whitelist-check/cla-database.csv
             """
                   .trimIndent()
           formatStderrAsError = true
-
-          conditions { doesNotContain("teamcity.pullRequest.source.branch", "dependabot/") }
         }
       }
 


### PR DESCRIPTION
This PR updates the whitelist check so that it skips it for dependabot raised PRs.