### PR TITLE
test: add coverage on node target validation

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/InvalidTextColumnMappingValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/InvalidTextColumnMappingValidator.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.neo4j.importer.v1.sources.Source;
+import org.neo4j.importer.v1.sources.TextSource;
+import org.neo4j.importer.v1.targets.Aggregation;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.RelationshipTarget;
+import org.neo4j.importer.v1.targets.SourceTransformations;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class InvalidTextColumnMappingValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "MCOL-002";
+
+    private final Map<String, Set<String>> sourceFields;
+
+    private final Map<String, String> invalidFields;
+
+    public InvalidTextColumnMappingValidator() {
+        this.sourceFields = new HashMap<>();
+        this.invalidFields = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitSource(int index, Source source) {
+        if (source instanceof TextSource) {
+            sourceFields.put(source.getName(), new HashSet<>(((TextSource) source).getHeader()));
+        }
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        visitEntity(index, target);
+    }
+
+    @Override
+    public void visitRelationshipTarget(int index, RelationshipTarget target) {
+        visitEntity(index, target);
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidFields.forEach((path, field) -> {
+            builder.addError(
+                    path,
+                    ERROR_CODE,
+                    String.format(
+                            "%s field \"%s\" is neither defined in the target's text source nor its source transformations",
+                            path, field));
+        });
+        return !invalidFields.isEmpty();
+    }
+
+    private void visitEntity(int index, EntityTarget target) {
+        var source = target.getSource();
+        if (!sourceFields.containsKey(source)) {
+            return;
+        }
+        var sourceFields = this.sourceFields.get(source);
+        var aggregatedFields = getAggregatedFields(target);
+        var mappings = target.getProperties();
+        var group = target instanceof NodeTarget ? "nodes" : "relationships";
+        for (int i = 0; i < mappings.size(); i++) {
+            var path = String.format("$.targets.%s[%d].properties[%d].source_field", group, index, i);
+            String sourceField = mappings.get(i).getSourceField();
+            if (!sourceFields.contains(sourceField) && !aggregatedFields.contains(sourceField)) {
+                invalidFields.put(path, sourceField);
+            }
+        }
+    }
+
+    private static Set<String> getAggregatedFields(EntityTarget target) {
+        var aggregatedFields = new HashSet<String>();
+        SourceTransformations sourceTransformations = target.getSourceTransformations();
+        if (sourceTransformations != null) {
+            sourceTransformations.getAggregations().stream()
+                    .map(Aggregation::getFieldName)
+                    .forEach(aggregatedFields::add);
+        }
+        return aggregatedFields;
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedAggregateFieldNameValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedAggregateFieldNameValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.Aggregation;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.RelationshipTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDuplicatedAggregateFieldNameValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DUPL-007";
+
+    private final Map<String, Duplicate<String>> duplicatedAggregateFields;
+
+    public NoDuplicatedAggregateFieldNameValidator() {
+        this.duplicatedAggregateFields = new LinkedHashMap<>();
+    }
+
+    @Override
+    public Set<Class<? extends SpecificationValidator>> requires() {
+        return Set.of(NoDuplicatedWithSourceAggregateFieldNameValidator.class);
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        visitEntity(index, target);
+    }
+
+    @Override
+    public void visitRelationshipTarget(int index, RelationshipTarget target) {
+        visitEntity(index, target);
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        duplicatedAggregateFields.forEach((path, duplicate) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format(
+                        "%s \"%s\" must be defined only once but is currently defined %d times within this target's aggregations",
+                        path, duplicate.getValue(), duplicate.getCount())));
+        return !duplicatedAggregateFields.isEmpty();
+    }
+
+    private void visitEntity(int index, EntityTarget target) {
+        var sourceTransformations = target.getSourceTransformations();
+        if (sourceTransformations == null) {
+            return;
+        }
+        var aggregations = sourceTransformations.getAggregations();
+        var aggregatedFieldNames =
+                aggregations.stream().map(Aggregation::getFieldName).collect(Collectors.toList());
+        var group = target instanceof NodeTarget ? "nodes" : "relationships";
+        Duplicate.findDuplicates(aggregatedFieldNames).forEach(duplicate -> {
+            int aggregateIndex = aggregatedFieldNames.indexOf(duplicate.getValue());
+            var path = String.format(
+                    "$.targets.%s[%d].source_transformations.aggregations[%d].field_name",
+                    group, index, aggregateIndex);
+            duplicatedAggregateFields.put(path, duplicate);
+        });
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedLabelValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedLabelValidator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDuplicatedLabelValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DUPL-008";
+
+    private final Map<String, Duplicate<String>> duplicateLabels;
+
+    public NoDuplicatedLabelValidator() {
+        this.duplicateLabels = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var labels = target.getLabels();
+        Duplicate.findDuplicates(labels).forEach(duplicate -> {
+            var i = labels.indexOf(duplicate.getValue());
+            var path = String.format("$.targets.nodes[%d].labels[%d]", index, i);
+            duplicateLabels.put(path, duplicate);
+        });
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        duplicateLabels.forEach((path, duplicate) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format(
+                        "%s \"%s\" must be defined only once but found %d occurrences",
+                        path, duplicate.getValue(), duplicate.getCount())));
+        return !duplicateLabels.isEmpty();
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedSourceHeaderColumnValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedSourceHeaderColumnValidator.java
@@ -26,12 +26,12 @@ import org.neo4j.importer.v1.sources.TextSource;
 import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
 import org.neo4j.importer.v1.validation.SpecificationValidator;
 
-public class NoDuplicatedSourceHeaderColumn implements SpecificationValidator {
+public class NoDuplicatedSourceHeaderColumnValidator implements SpecificationValidator {
     private static final String ERROR_CODE = "DUPL-002";
 
     private final Map<String, Duplicate<String>> sourcePathToDuplicates;
 
-    public NoDuplicatedSourceHeaderColumn() {
+    public NoDuplicatedSourceHeaderColumnValidator() {
         sourcePathToDuplicates = new LinkedHashMap<>();
     }
 

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedTargetPropertyValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedTargetPropertyValidator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.PropertyMapping;
+import org.neo4j.importer.v1.targets.RelationshipTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDuplicatedTargetPropertyValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DUPL-009";
+
+    private final Map<String, Duplicate<String>> duplicateProperties;
+
+    public NoDuplicatedTargetPropertyValidator() {
+        this.duplicateProperties = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        visitEntity(index, target);
+    }
+
+    @Override
+    public void visitRelationshipTarget(int index, RelationshipTarget target) {
+        visitEntity(index, target);
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        duplicateProperties.forEach((path, duplicate) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format(
+                        "%s \"%s\" must be defined only once but found %d occurrences",
+                        path, duplicate.getValue(), duplicate.getCount())));
+        return !duplicateProperties.isEmpty();
+    }
+
+    private void visitEntity(int index, EntityTarget target) {
+        var properties = target.getProperties().stream()
+                .map(PropertyMapping::getTargetProperty)
+                .collect(Collectors.toList());
+        var group = target instanceof NodeTarget ? "nodes" : "relationships";
+        Duplicate.findDuplicates(properties).forEach(duplicate -> {
+            var i = properties.indexOf(duplicate.getValue());
+            var path = String.format("$.targets.%s[%d].properties[%d].target_property", group, index, i);
+            duplicateProperties.put(path, duplicate);
+        });
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedWithSourceAggregateFieldNameValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedWithSourceAggregateFieldNameValidator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.neo4j.importer.v1.sources.Source;
+import org.neo4j.importer.v1.sources.TextSource;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.RelationshipTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDuplicatedWithSourceAggregateFieldNameValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DUPL-006";
+
+    private final Map<String, Set<String>> sourceFields;
+    private final Map<String, String> duplicatedAggregateFields;
+
+    public NoDuplicatedWithSourceAggregateFieldNameValidator() {
+        this.sourceFields = new HashMap<>();
+        this.duplicatedAggregateFields = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitSource(int index, Source source) {
+        if (source instanceof TextSource) {
+            sourceFields.put(source.getName(), new HashSet<>(((TextSource) source).getHeader()));
+        }
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        visitEntity(index, target);
+    }
+
+    @Override
+    public void visitRelationshipTarget(int index, RelationshipTarget target) {
+        visitEntity(index, target);
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        duplicatedAggregateFields.forEach((path, field) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format("%s \"%s\" is already defined in the target's source header", path, field)));
+        return !duplicatedAggregateFields.isEmpty();
+    }
+
+    private void visitEntity(int index, EntityTarget target) {
+        var source = target.getSource();
+        if (!sourceFields.containsKey(source)) {
+            return;
+        }
+        var sourceFields = this.sourceFields.get(source);
+        var sourceTransformations = target.getSourceTransformations();
+        if (sourceTransformations == null) {
+            return;
+        }
+        var aggregations = sourceTransformations.getAggregations();
+        var group = target instanceof NodeTarget ? "nodes" : "relationships";
+        for (int i = 0; i < aggregations.size(); i++) {
+            var path = String.format(
+                    "$.targets.%s[%d].source_transformations.aggregations[%d].field_name", group, index, i);
+            var aggregatedField = aggregations.get(i).getFieldName();
+            if (sourceFields.contains(aggregatedField)) {
+                duplicatedAggregateFields.put(path, aggregatedField);
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -3,9 +3,14 @@ org.neo4j.importer.v1.validation.plugin.NoDanglingSourceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingDependsOnValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDependencyCycleValidator
-org.neo4j.importer.v1.validation.plugin.NoDuplicatedSourceHeaderColumn
+org.neo4j.importer.v1.validation.plugin.NoDuplicatedSourceHeaderColumnValidator
 org.neo4j.importer.v1.validation.plugin.NoInconsistentInlineSourceDataValidator
 org.neo4j.importer.v1.validation.plugin.AtLeastOneActiveTargetValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedDependencyValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingActiveNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedSourceNameValidator
+org.neo4j.importer.v1.validation.plugin.InvalidTextColumnMappingValidator
+org.neo4j.importer.v1.validation.plugin.NoDuplicatedWithSourceAggregateFieldNameValidator
+org.neo4j.importer.v1.validation.plugin.NoDuplicatedAggregateFieldNameValidator
+org.neo4j.importer.v1.validation.plugin.NoDuplicatedLabelValidator
+org.neo4j.importer.v1.validation.plugin.NoDuplicatedTargetPropertyValidator

--- a/src/main/resources/spec.v1.json
+++ b/src/main/resources/spec.v1.json
@@ -361,7 +361,8 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S+"
           },
           "minItems": 1
         },
@@ -710,10 +711,14 @@
             "type": "object",
             "properties": {
               "expression": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "pattern": "\\S+"
               },
               "field_name": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "pattern": "\\S+"
               }
             },
             "required": [
@@ -725,7 +730,9 @@
           "minItems": 1
         },
         "where": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "order_by": {
           "type": "array",
@@ -733,15 +740,15 @@
             "type": "object",
             "properties": {
               "expression": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "pattern": "\\S+"
               },
               "order": {
                 "type": "string",
                 "enum": [
                   "ASC",
-                  "asc",
-                  "DESC",
-                  "desc"
+                  "DESC"
                 ]
               }
             },
@@ -764,11 +771,13 @@
       "properties": {
         "source_field": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "target_property": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "target_property_type": {
           "type": "string",
@@ -799,7 +808,10 @@
           ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "source_field", "target_property"
+      ]
     },
     "target.node.schema.constraints.type": {
       "type": "object",

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -1318,8 +1318,8 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                                     "depends_on": ["a-query-target", "a-query-target"],
                                     "write_mode": "create",
                                     "properties": [
-                                        {"source_field": "field_1", "target_property": "property1"},
-                                        {"source_field": "field_2", "target_property": "property2"}
+                                        {"source_field": "column1", "target_property": "property1"},
+                                        {"source_field": "column2", "target_property": "property2"}
                                     ]
                                 }],
                                 "queries": [{
@@ -1366,8 +1366,8 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                                     "write_mode": "merge",
                                     "labels": ["Label1", "Label2"],
                                     "properties": [
-                                        {"source_field": "field_1", "target_property": "property1"},
-                                        {"source_field": "field_2", "target_property": "property2"}
+                                        {"source_field": "column1", "target_property": "property1"},
+                                        {"source_field": "column2", "target_property": "property2"}
                                     ]
                                 }],
                                 "relationships": [{
@@ -1428,8 +1428,8 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                                    "write_mode": "merge",
                                    "labels": ["Label1", "Label2"],
                                    "properties": [
-                                       {"source_field": "field_1", "target_property": "property1"},
-                                       {"source_field": "field_2", "target_property": "property2"}
+                                       {"source_field": "column1", "target_property": "property1"},
+                                       {"source_field": "column2", "target_property": "property2"}
                                    ]
                                }],
                                 "relationships": [{
@@ -1484,8 +1484,8 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                                    "write_mode": "merge",
                                    "labels": ["Label1", "Label2"],
                                    "properties": [
-                                       {"source_field": "field_1", "target_property": "property1"},
-                                       {"source_field": "field_2", "target_property": "property2"}
+                                       {"source_field": "column1", "target_property": "property1"},
+                                       {"source_field": "column2", "target_property": "property2"}
                                    ]
                                }],
                                 "relationships": [{

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -1,0 +1,1908 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.neo4j.importer.v1.ImportSpecificationDeserializer.deserialize;
+
+import java.io.StringReader;
+import org.junit.Test;
+import org.neo4j.importer.v1.validation.InvalidSpecificationException;
+
+public class ImportSpecificationDeserializerNodeTargetTest {
+
+    @Test
+    public void fails_if_node_target_active_attribute_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": 42,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)", "0 warning(s)", "$.targets.nodes[0].active: integer found, boolean expected");
+    }
+
+    @Test
+    public void fails_if_node_target_write_mode_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": 42,
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)", "$.targets.nodes[0].write_mode: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_write_mode_has_wrong_value() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "reticulating_splines",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].write_mode: does not have a value in the enumeration [create, merge]");
+    }
+
+    @Test
+    public void fails_if_node_target_labels_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)", "0 warning(s)", "$.targets.nodes[0]: required property 'labels' not found");
+    }
+
+    @Test
+    public void fails_if_node_target_labels_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": 42,
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)", "0 warning(s)", "$.targets.nodes[0].labels: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_target_labels_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": [],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].labels: must have at least 1 items but found 0");
+    }
+
+    @Test
+    public void fails_if_node_target_labels_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": [42],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)", "0 warning(s)", "$.targets.nodes[0].labels[0]: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_labels_element_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": [""],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)", "$.targets.nodes[0].labels[0]: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_target_labels_element_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["   "],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].labels[0]: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_target_labels_are_duplicated() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label1", "Label1", "Label2", "Label2", "Label2"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "2 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].labels[0] \"Label1\" must be defined only once but found 2 occurrences",
+                        "$.targets.nodes[0].labels[2] \"Label2\" must be defined only once but found 3 occurrences");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)", "0 warning(s)", "$.targets.nodes[0]: required property 'properties' not found");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": 42
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)", "0 warning(s)", "$.targets.nodes[0].properties: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [42]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_source_field_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0]: required property 'source_field' not found");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_source_field_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": 42, "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].source_field: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_source_field_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].source_field: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_source_field_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "   ", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].source_field: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_source_field_is_not_listed_in_text_source_fields() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "text",
+        "header": ["field-1"],
+        "data": [
+            ["foo"], ["bar"]
+        ]
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "invalid-field", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].source_field field \"invalid-field\" is neither defined in the target's text source nor its source transformations");
+    }
+
+    @Test
+    public void does_not_fail_if_node_target_property_mappings_source_field_is_listed_in_target_aggregations() {
+        assertThatCode(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "text",
+        "header": ["field-1"],
+        "data": [
+            ["foo"], ["bar"]
+        ]
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "source_transformations": {
+                "aggregations": [{
+                    "field_name": "aggregated", "expression": "42"
+                }]
+            },
+            "properties": [
+                {"source_field": "aggregated", "target_property": "property"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_target_property_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+"version": "1",
+"sources": [{
+"name": "a-source",
+"type": "jdbc",
+"data_source": "a-data-source",
+"sql": "SELECT id, name FROM my.table"
+}],
+"targets": {
+"nodes": [{
+    "active": true,
+    "name": "a-target",
+    "source": "a-source",
+    "labels": ["Label"],
+    "properties": [
+        {"source_field": "id"}
+    ]
+}]
+}
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0]: required property 'target_property' not found");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_target_property_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+"version": "1",
+"sources": [{
+"name": "a-source",
+"type": "jdbc",
+"data_source": "a-data-source",
+"sql": "SELECT id, name FROM my.table"
+}],
+"targets": {
+"nodes": [{
+    "active": true,
+    "name": "a-target",
+    "source": "a-source",
+    "labels": ["Label"],
+    "properties": [
+        {"source_field": "id", "target_property": 42}
+    ]
+}]
+}
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].target_property: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_target_property_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+"version": "1",
+"sources": [{
+"name": "a-source",
+"type": "jdbc",
+"data_source": "a-data-source",
+"sql": "SELECT id, name FROM my.table"
+}],
+"targets": {
+"nodes": [{
+    "active": true,
+    "name": "a-target",
+    "source": "a-source",
+    "labels": ["Label"],
+    "properties": [
+        {"source_field": "id", "target_property": ""}
+    ]
+}]
+}
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].target_property: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_target_property_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+"version": "1",
+"sources": [{
+"name": "a-source",
+"type": "jdbc",
+"data_source": "a-data-source",
+"sql": "SELECT id, name FROM my.table"
+}],
+"targets": {
+"nodes": [{
+    "active": true,
+    "name": "a-target",
+    "source": "a-source",
+    "labels": ["Label"],
+    "properties": [
+        {"source_field": "id", "target_property": "   "}
+    ]
+}]
+}
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].target_property: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_target_property_is_duplicated() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+"version": "1",
+"sources": [{
+"name": "a-source",
+"type": "jdbc",
+"data_source": "a-data-source",
+"sql": "SELECT id, name FROM my.table"
+}],
+"targets": {
+"nodes": [{
+    "active": true,
+    "name": "a-target",
+    "source": "a-source",
+    "labels": ["Label"],
+    "properties": [
+        {"source_field": "id", "target_property": "property"},
+        {"source_field": "name", "target_property": "property"}
+    ]
+}]
+}
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].target_property \"property\" must be defined only once but found 2 occurrences");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_target_property_type_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+"version": "1",
+"sources": [{
+"name": "a-source",
+"type": "jdbc",
+"data_source": "a-data-source",
+"sql": "SELECT id, name FROM my.table"
+}],
+"targets": {
+"nodes": [{
+    "active": true,
+    "name": "a-target",
+    "source": "a-source",
+    "labels": ["Label"],
+    "properties": [
+        {"source_field": "id", "target_property": "property", "target_property_type": 42}
+    ]
+}]
+}
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].target_property_type: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_property_mappings_target_property_type_is_unsupported() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+"version": "1",
+"sources": [{
+"name": "a-source",
+"type": "jdbc",
+"data_source": "a-data-source",
+"sql": "SELECT id, name FROM my.table"
+}],
+"targets": {
+"nodes": [{
+    "active": true,
+    "name": "a-target",
+    "source": "a-source",
+    "labels": ["Label"],
+    "properties": [
+        {"source_field": "id", "target_property": "property", "target_property_type": "blackhole"}
+    ]
+}]
+}
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].properties[0].target_property_type: does not have a value in the enumeration [boolean, boolean_array, byte_array, date, date_array, duration, duration_array, float, float_array, integer, integer_array, local_datetime, local_datetime_array, local_time, local_time_array, point, point_array, string, string_array, zoned_datetime, zoned_datetime_array, zoned_time, zoned_time_array]");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_enable_grouping_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "enable_grouping": 42
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.enable_grouping: integer found, boolean expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_have_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": 42
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_element_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [42]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_expression_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "field_name": "field_2"
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0]: required property 'expression' not found");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_expression_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": 42,
+                    "field_name": "field_2"
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0].expression: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_expression_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": "",
+                    "field_name": "field_2"
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0].expression: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_expression_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": "  ",
+                    "field_name": "field_2"
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0].expression: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_field_name_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": "42"
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0]: required property 'field_name' not found");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_field_name_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": "42",
+                    "field_name": 42
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0].field_name: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_field_name_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": "42",
+                    "field_name": ""
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0].field_name: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_field_name_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": "42",
+                    "field_name": " "
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0].field_name: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_field_names_clash() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "text",
+        "header": ["field_1"],
+        "data": [
+            ["foo"], ["bar"]
+        ]
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property1"},
+                {"source_field": "field_2", "target_property": "property2"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": "42",
+                    "field_name": "field_2"
+                },{
+                    "expression": "42",
+                    "field_name": "field_2"
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0].field_name \"field_2\" must be defined only once but is currently defined 2 times within this target's aggregations");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_aggregations_field_name_clashes_with_text_source_fields() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "text",
+        "header": ["field_1"],
+        "data": [
+            ["foo"], ["bar"]
+        ]
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "aggregations": [{
+                    "expression": "42",
+                    "field_name": "field_1"
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.aggregations[0].field_name \"field_1\" is already defined in the target's source header");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_where_clause_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "where": 42
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.where: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_where_clause_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "where": ""
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.where: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_where_clause_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "where": "  "
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.where: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_order_by_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "order_by": 42
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.order_by: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_order_by_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "order_by": [42]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.order_by[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_order_by_expression_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "order_by": [{}]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.order_by[0]: required property 'expression' not found");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_order_by_expression_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "order_by": [{
+                    "expression": 42
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.order_by[0].expression: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_order_by_expression_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "order_by": [{
+                    "expression": ""
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.order_by[0].expression: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_order_by_expression_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "order_by": [{
+                    "expression": "   "
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.order_by[0].expression: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_order_by_order_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "order_by": [{
+                    "expression": "42",
+                    "order": 42
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.order_by[0].order: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_order_by_order_has_wrong_value() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "order_by": [{
+                    "expression": "42",
+                    "order": "new"
+                }]
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.order_by[0].order: does not have a value in the enumeration [ASC, DESC]");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_limit_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field_1", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "limit": []
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.limit: array found, integer expected");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_limit_is_negative() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "limit": -42
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.limit: must have a minimum value of 1");
+    }
+
+    @Test
+    public void fails_if_node_target_source_transformation_limit_is_zero() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "field", "target_property": "property"}
+            ],
+            "source_transformations": {
+                "limit": 0
+            }
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].source_transformations.limit: must have a minimum value of 1");
+    }
+}


### PR DESCRIPTION
This commit adds validation on active, source, labels, source transformations and property mappings.