### PR TITLE
test: add coverage on relationship target validation

### DIFF
--- a/src/main/resources/spec.v1.json
+++ b/src/main/resources/spec.v1.json
@@ -109,7 +109,8 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "name": {
           "type": "string",
@@ -257,7 +258,8 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "start_node_reference": {
           "type": "string",

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -32,32 +32,32 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     void fails_if_source_name_is_duplicated() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "duplicate",
-                        "query": "SELECT id, name FROM my.table"
-                    },
-                    {
-                        "type": "bigquery",
-                        "name": "duplicate",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "name": "target",
-                            "source": "duplicate",
-                            "labels": ["Label1", "Label2"],
-                            "write_mode": "create",
-                            "properties": [
-                                {"source_field": "field_1", "target_property": "property1"},
-                                {"source_field": "field_2", "target_property": "property2"}
-                            ]
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "duplicate",
+                                "query": "SELECT id, name FROM my.table"
+                            },
+                            {
+                                "type": "bigquery",
+                                "name": "duplicate",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "target",
+                                    "source": "duplicate",
+                                    "labels": ["Label1", "Label2"],
+                                    "write_mode": "create",
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property1"},
+                                        {"source_field": "field_2", "target_property": "property2"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -71,27 +71,27 @@ public class ImportSpecificationDeserializerExtraValidationTest {
         assertThatNoException()
                 .isThrownBy(() -> deserialize(new StringReader(
                         """
-                        {
-                            "version": "1",
-                            "sources": [{
-                                "type": "bigquery",
-                                "name": "not-duplicate",
-                                "query": "SELECT id, name FROM my.table"
-                            }],
-                            "targets": {
-                                "nodes": [{
-                                    "name": "not-duplicate",
-                                    "source": "not-duplicate",
-                                    "labels": ["Label1", "Label2"],
-                                    "write_mode": "create",
-                                    "properties": [
-                                        {"source_field": "field_1", "target_property": "property1"},
-                                        {"source_field": "field_2", "target_property": "property2"}
-                                    ]
-                                }]
-                            }
-                        }
-                        """
+                                {
+                                    "version": "1",
+                                    "sources": [{
+                                        "type": "bigquery",
+                                        "name": "not-duplicate",
+                                        "query": "SELECT id, name FROM my.table"
+                                    }],
+                                    "targets": {
+                                        "nodes": [{
+                                            "name": "not-duplicate",
+                                            "source": "not-duplicate",
+                                            "labels": ["Label1", "Label2"],
+                                            "write_mode": "create",
+                                            "properties": [
+                                                {"source_field": "field_1", "target_property": "property1"},
+                                                {"source_field": "field_2", "target_property": "property2"}
+                                            ]
+                                        }]
+                                    }
+                                }
+                                """
                                 .stripIndent())));
     }
 
@@ -100,34 +100,34 @@ public class ImportSpecificationDeserializerExtraValidationTest {
         assertThatNoException()
                 .isThrownBy(() -> deserialize(new StringReader(
                         """
-                        {
-                            "version": "1",
-                            "sources": [{
-                                "type": "bigquery",
-                                "name": "not-duplicate",
-                                "query": "SELECT id, name FROM my.table"
-                            }],
-                            "targets": {
-                                "nodes": [{
-                                    "name": "target",
-                                    "source": "not-duplicate",
-                                    "labels": ["Label1", "Label2"],
-                                    "write_mode": "create",
-                                    "properties": [
-                                        {"source_field": "field_1", "target_property": "property1"},
-                                        {"source_field": "field_2", "target_property": "property2"}
-                                    ]
-                                }]
-                            },
-                            "actions": [{
-                                "name": "not-duplicate",
-                                "type": "http",
-                                "method": "get",
-                                "stage": "pre_relationships",
-                                "url": "https://example.com"
-                            }]
-                        }
-                        """
+                                {
+                                    "version": "1",
+                                    "sources": [{
+                                        "type": "bigquery",
+                                        "name": "not-duplicate",
+                                        "query": "SELECT id, name FROM my.table"
+                                    }],
+                                    "targets": {
+                                        "nodes": [{
+                                            "name": "target",
+                                            "source": "not-duplicate",
+                                            "labels": ["Label1", "Label2"],
+                                            "write_mode": "create",
+                                            "properties": [
+                                                {"source_field": "field_1", "target_property": "property1"},
+                                                {"source_field": "field_2", "target_property": "property2"}
+                                            ]
+                                        }]
+                                    },
+                                    "actions": [{
+                                        "name": "not-duplicate",
+                                        "type": "http",
+                                        "method": "get",
+                                        "stage": "pre_relationships",
+                                        "url": "https://example.com"
+                                    }]
+                                }
+                                """
                                 .stripIndent())));
     }
 
@@ -588,44 +588,44 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     void fails_if_active_relationship_target_refers_to_an_inactive_node_target_for_end() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "source": "a-source",
-                            "name": "a-node-target",
-                            "write_mode": "merge",
-                            "labels": ["Label1", "Label2"],
-                            "properties": [
-                                {"source_field": "field_1", "target_property": "property1"},
-                                {"source_field": "field_2", "target_property": "property2"}
-                            ]
-                        },{
-                            "active": false,
-                            "source": "a-source",
-                            "name": "another-node-target",
-                            "write_mode": "merge",
-                            "labels": ["Label3"],
-                            "properties": [
-                                {"source_field": "field_1", "target_property": "property1"},
-                                {"source_field": "field_2", "target_property": "property2"}
-                            ]
-                        }],
-                        "relationships": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "type": "TYPE",
-                            "start_node_reference": "a-node-target",
-                            "end_node_reference": "another-node-target"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "source": "a-source",
+                                    "name": "a-node-target",
+                                    "write_mode": "merge",
+                                    "labels": ["Label1", "Label2"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property1"},
+                                        {"source_field": "field_2", "target_property": "property2"}
+                                    ]
+                                },{
+                                    "active": false,
+                                    "source": "a-source",
+                                    "name": "another-node-target",
+                                    "write_mode": "merge",
+                                    "labels": ["Label3"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property1"},
+                                        {"source_field": "field_2", "target_property": "property2"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "another-node-target"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -639,45 +639,45 @@ public class ImportSpecificationDeserializerExtraValidationTest {
         assertThatNoException()
                 .isThrownBy(() -> deserialize(new StringReader(
                         """
-                        {
-                            "version": "1",
-                            "sources": [{
-                                "type": "bigquery",
-                                "name": "a-source",
-                                "query": "SELECT id, name FROM my.table"
-                            }],
-                            "targets": {
-                                "nodes": [{
-                                    "active": false,
-                                    "source": "a-source",
-                                    "name": "a-node-target",
-                                    "write_mode": "merge",
-                                    "labels": ["Label1", "Label2"],
-                                    "properties": [
-                                        {"source_field": "field_1", "target_property": "property1"},
-                                        {"source_field": "field_2", "target_property": "property2"}
-                                    ]
-                                },{
-                                    "source": "a-source",
-                                    "name": "another-node-target",
-                                    "write_mode": "merge",
-                                    "labels": ["Label3"],
-                                    "properties": [
-                                        {"source_field": "field_1", "target_property": "property1"},
-                                        {"source_field": "field_2", "target_property": "property2"}
-                                    ]
-                                }],
-                                "relationships": [{
-                                    "active": false,
-                                    "name": "a-target",
-                                    "source": "a-source",
-                                    "type": "TYPE",
-                                    "start_node_reference": "a-node-target",
-                                    "end_node_reference": "another-node-target"
-                                }]
-                            }
-                        }
-                        """
+                                {
+                                    "version": "1",
+                                    "sources": [{
+                                        "type": "bigquery",
+                                        "name": "a-source",
+                                        "query": "SELECT id, name FROM my.table"
+                                    }],
+                                    "targets": {
+                                        "nodes": [{
+                                            "active": false,
+                                            "source": "a-source",
+                                            "name": "a-node-target",
+                                            "write_mode": "merge",
+                                            "labels": ["Label1", "Label2"],
+                                            "properties": [
+                                                {"source_field": "field_1", "target_property": "property1"},
+                                                {"source_field": "field_2", "target_property": "property2"}
+                                            ]
+                                        },{
+                                            "source": "a-source",
+                                            "name": "another-node-target",
+                                            "write_mode": "merge",
+                                            "labels": ["Label3"],
+                                            "properties": [
+                                                {"source_field": "field_1", "target_property": "property1"},
+                                                {"source_field": "field_2", "target_property": "property2"}
+                                            ]
+                                        }],
+                                        "relationships": [{
+                                            "active": false,
+                                            "name": "a-target",
+                                            "source": "a-source",
+                                            "type": "TYPE",
+                                            "start_node_reference": "a-node-target",
+                                            "end_node_reference": "another-node-target"
+                                        }]
+                                    }
+                                }
+                                """
                                 .stripIndent())));
     }
 
@@ -686,45 +686,45 @@ public class ImportSpecificationDeserializerExtraValidationTest {
         assertThatNoException()
                 .isThrownBy(() -> deserialize(new StringReader(
                         """
-                        {
-                            "version": "1",
-                            "sources": [{
-                                "type": "bigquery",
-                                "name": "a-source",
-                                "query": "SELECT id, name FROM my.table"
-                            }],
-                            "targets": {
-                                "nodes": [{
-                                    "source": "a-source",
-                                    "name": "a-node-target",
-                                    "write_mode": "merge",
-                                    "labels": ["Label1", "Label2"],
-                                    "properties": [
-                                        {"source_field": "field_1", "target_property": "property1"},
-                                        {"source_field": "field_2", "target_property": "property2"}
-                                    ]
-                                },{
-                                    "active": false,
-                                    "source": "a-source",
-                                    "name": "another-node-target",
-                                    "write_mode": "merge",
-                                    "labels": ["Label3"],
-                                    "properties": [
-                                        {"source_field": "field_1", "target_property": "property1"},
-                                        {"source_field": "field_2", "target_property": "property2"}
-                                    ]
-                                }],
-                                "relationships": [{
-                                    "active": false,
-                                    "name": "a-target",
-                                    "source": "a-source",
-                                    "type": "TYPE",
-                                    "start_node_reference": "a-node-target",
-                                    "end_node_reference": "another-node-target"
-                                }]
-                            }
-                        }
-                        """
+                                {
+                                    "version": "1",
+                                    "sources": [{
+                                        "type": "bigquery",
+                                        "name": "a-source",
+                                        "query": "SELECT id, name FROM my.table"
+                                    }],
+                                    "targets": {
+                                        "nodes": [{
+                                            "source": "a-source",
+                                            "name": "a-node-target",
+                                            "write_mode": "merge",
+                                            "labels": ["Label1", "Label2"],
+                                            "properties": [
+                                                {"source_field": "field_1", "target_property": "property1"},
+                                                {"source_field": "field_2", "target_property": "property2"}
+                                            ]
+                                        },{
+                                            "active": false,
+                                            "source": "a-source",
+                                            "name": "another-node-target",
+                                            "write_mode": "merge",
+                                            "labels": ["Label3"],
+                                            "properties": [
+                                                {"source_field": "field_1", "target_property": "property1"},
+                                                {"source_field": "field_2", "target_property": "property2"}
+                                            ]
+                                        }],
+                                        "relationships": [{
+                                            "active": false,
+                                            "name": "a-target",
+                                            "source": "a-source",
+                                            "type": "TYPE",
+                                            "start_node_reference": "a-node-target",
+                                            "end_node_reference": "another-node-target"
+                                        }]
+                                    }
+                                }
+                                """
                                 .stripIndent())));
     }
 
@@ -1409,27 +1409,27 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     public void fails_if_node_target_labels_are_duplicated() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "jdbc",
-                        "data_source": "a-data-source",
-                        "sql": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "active": true,
-                            "name": "a-target",
-                            "source": "a-source",
-                            "labels": ["Label1", "Label1", "Label2", "Label2", "Label2"],
-                            "properties": [
-                                {"source_field": "field", "target_property": "property"}
-                            ]
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label1", "Label1", "Label2", "Label2", "Label2"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1443,27 +1443,27 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     public void fails_if_node_target_property_mappings_target_property_is_duplicated() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                             {
-                             "version": "1",
-                             "sources": [{
-                               "name": "a-source",
-                               "type": "jdbc",
-                               "data_source": "a-data-source",
-                               "sql": "SELECT id, name FROM my.table"
-                             }],
-                             "targets": {
-                               "nodes": [{
-                                 "active": true,
-                                 "name": "a-target",
-                                 "source": "a-source",
-                                 "labels": ["Label"],
-                                 "properties": [
-                                   {"source_field": "id", "target_property": "property"},
-                                   {"source_field": "name", "target_property": "property"}
-                                 ]
-                               }]
-                             }
-                           }"""
+                          {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "active": true,
+                              "name": "a-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "property"},
+                                {"source_field": "name", "target_property": "property"}
+                              ]
+                            }]
+                          }
+                        }"""
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1476,37 +1476,37 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     public void fails_if_relationship_target_property_mappings_target_property_is_duplicated() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "property"},
-                        {"source_field": "name", "target_property": "property"}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "property"},
+                                {"source_field": "name", "target_property": "property"}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1519,39 +1519,39 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     public void fails_if_node_target_source_transformation_aggregations_field_names_clash() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "text",
-"header": ["field_1"],
-"data": [
-    ["foo"], ["bar"]
-]
-}],
-"targets": {
-"nodes": [{
-    "name": "a-target",
-    "source": "a-source",
-    "write_mode": "merge",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "field_1", "target_property": "property1"},
-        {"source_field": "field_2", "target_property": "property2"}
-    ],
-    "source_transformations": {
-        "aggregations": [{
-            "expression": "42",
-            "field_name": "field_2"
-        },{
-            "expression": "42",
-            "field_name": "field_2"
-        }]
-    }
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "text",
+                        "header": ["field_1"],
+                        "data": [
+                            ["foo"], ["bar"]
+                        ]
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field_1", "target_property": "property1"},
+                                {"source_field": "field_2", "target_property": "property2"}
+                            ],
+                            "source_transformations": {
+                                "aggregations": [{
+                                    "expression": "42",
+                                    "field_name": "field_2"
+                                },{
+                                    "expression": "42",
+                                    "field_name": "field_2"
+                                }]
+                            }
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1564,45 +1564,45 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     public void fails_if_relationship_target_source_transformation_aggregations_field_names_clash() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "aggregations": [{
-                              "expression": "42",
-                              "field_name": "field_2"
-                          },{
-                              "expression": "42",
-                              "field_name": "field_2"
-                          }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "aggregations": [{
+                                      "expression": "42",
+                                      "field_name": "field_2"
+                                  },{
+                                      "expression": "42",
+                                      "field_name": "field_2"
+                                  }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -30,28 +30,28 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_active_attribute_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": 42,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": 42,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -62,25 +62,25 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_attribute_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "name": "a-node-target",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": "id"}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "name": "a-node-target",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -91,26 +91,26 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_attribute_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "name": "a-node-target",
-    "source": 42,
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": "id"}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "name": "a-node-target",
+                            "source": 42,
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -121,26 +121,26 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_attribute_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "name": "a-node-target",
-    "source": "",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": "id"}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "name": "a-node-target",
+                            "source": "",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -151,26 +151,26 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_attribute_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "name": "a-node-target",
-    "source": "   ",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": "id"}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "name": "a-node-target",
+                            "source": "   ",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -183,28 +183,28 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_write_mode_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": 42,
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": 42,
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -215,28 +215,28 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_write_mode_has_wrong_value() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "reticulating_splines",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "reticulating_splines",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -249,26 +249,26 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_labels_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -279,27 +279,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_labels_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": 42,
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": 42,
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -310,27 +310,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_labels_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": [],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": [],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -343,27 +343,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_labels_element_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": [42],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": [42],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -374,27 +374,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_labels_element_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": [""],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": [""],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -405,27 +405,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_labels_element_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["   "],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["   "],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -438,24 +438,24 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["Label"]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -466,25 +466,25 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": 42
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": 42
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -495,25 +495,25 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_element_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [42]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [42]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -526,27 +526,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_source_field_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -559,27 +559,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_source_field_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": 42, "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": 42, "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -592,27 +592,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_source_field_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -624,27 +624,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_source_field_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "   ", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "   ", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -657,34 +657,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void does_not_fail_if_node_target_property_mappings_source_field_is_listed_in_target_aggregations() {
         assertThatCode(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "text",
-        "header": ["field-1"],
-        "data": [
-            ["foo"], ["bar"]
-        ]
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "source_transformations": {
-                "aggregations": [{
-                    "field_name": "aggregated", "expression": "42"
-                }]
-            },
-            "properties": [
-                {"source_field": "aggregated", "target_property": "property"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "text",
+                                "header": ["field-1"],
+                                "data": [
+                                    ["foo"], ["bar"]
+                                ]
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "field_name": "aggregated", "expression": "42"
+                                        }]
+                                    },
+                                    "properties": [
+                                        {"source_field": "aggregated", "target_property": "property"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .doesNotThrowAnyException();
     }
@@ -693,27 +693,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_target_property_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "active": true,
-    "name": "a-target",
-    "source": "a-source",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id"}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id"}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -726,27 +726,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_target_property_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "active": true,
-    "name": "a-target",
-    "source": "a-source",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": 42}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": 42}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -759,27 +759,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_target_property_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "active": true,
-    "name": "a-target",
-    "source": "a-source",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": ""}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": ""}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -791,27 +791,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_target_property_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "active": true,
-    "name": "a-target",
-    "source": "a-source",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": "   "}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "   "}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -824,27 +824,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_target_property_type_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "active": true,
-    "name": "a-target",
-    "source": "a-source",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": "property", "target_property_type": 42}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "property", "target_property_type": 42}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -856,27 +856,27 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_property_mappings_target_property_type_is_unsupported() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-"version": "1",
-"sources": [{
-"name": "a-source",
-"type": "jdbc",
-"data_source": "a-data-source",
-"sql": "SELECT id, name FROM my.table"
-}],
-"targets": {
-"nodes": [{
-    "active": true,
-    "name": "a-target",
-    "source": "a-source",
-    "labels": ["Label"],
-    "properties": [
-        {"source_field": "id", "target_property": "property", "target_property_type": "blackhole"}
-    ]
-}]
-}
-}
-"""
+                        {
+                        "version": "1",
+                        "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                        }],
+                        "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "property", "target_property_type": "blackhole"}
+                            ]
+                        }]
+                        }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -889,31 +889,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_enable_grouping_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "enable_grouping": 42
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "enable_grouping": 42
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -926,31 +926,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_have_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": 42
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": 42
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -963,31 +963,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_element_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [42]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [42]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1000,33 +1000,33 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_expression_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [{
-                    "field_name": "field_2"
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "field_name": "field_2"
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1039,34 +1039,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_expression_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [{
-                    "expression": 42,
-                    "field_name": "field_2"
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "expression": 42,
+                                            "field_name": "field_2"
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1079,34 +1079,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_expression_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [{
-                    "expression": "",
-                    "field_name": "field_2"
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "expression": "",
+                                            "field_name": "field_2"
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1118,34 +1118,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_expression_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [{
-                    "expression": "  ",
-                    "field_name": "field_2"
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "expression": "  ",
+                                            "field_name": "field_2"
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1158,33 +1158,33 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_field_name_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [{
-                    "expression": "42"
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "expression": "42"
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1197,34 +1197,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_field_name_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [{
-                    "expression": "42",
-                    "field_name": 42
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "expression": "42",
+                                            "field_name": 42
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1237,34 +1237,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_field_name_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [{
-                    "expression": "42",
-                    "field_name": ""
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "expression": "42",
+                                            "field_name": ""
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1276,34 +1276,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_aggregations_field_name_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "aggregations": [{
-                    "expression": "42",
-                    "field_name": " "
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "aggregations": [{
+                                            "expression": "42",
+                                            "field_name": " "
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1316,31 +1316,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_where_clause_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "where": 42
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "where": 42
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1353,31 +1353,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_where_clause_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "where": ""
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "where": ""
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1389,31 +1389,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_where_clause_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "where": "  "
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "where": "  "
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1426,31 +1426,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_order_by_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "order_by": 42
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "order_by": 42
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1463,31 +1463,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_order_by_element_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "order_by": [42]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "order_by": [42]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1500,31 +1500,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_order_by_expression_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "order_by": [{}]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "order_by": [{}]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1537,33 +1537,33 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_order_by_expression_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "order_by": [{
-                    "expression": 42
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "order_by": [{
+                                            "expression": 42
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1576,33 +1576,33 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_order_by_expression_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "order_by": [{
-                    "expression": ""
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "order_by": [{
+                                            "expression": ""
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1614,33 +1614,33 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_order_by_expression_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "order_by": [{
-                    "expression": "   "
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "order_by": [{
+                                            "expression": "   "
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1653,34 +1653,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_order_by_order_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "order_by": [{
-                    "expression": "42",
-                    "order": 42
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "order_by": [{
+                                            "expression": "42",
+                                            "order": 42
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1692,34 +1692,34 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_order_by_order_has_wrong_value() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "order_by": [{
-                    "expression": "42",
-                    "order": "new"
-                }]
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "order_by": [{
+                                            "expression": "42",
+                                            "order": "new"
+                                        }]
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1731,31 +1731,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_limit_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field_1", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "limit": []
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "limit": []
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1768,31 +1768,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_limit_is_negative() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "limit": -42
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "limit": -42
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1805,31 +1805,31 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     public void fails_if_node_target_source_transformation_limit_is_zero() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "active": true,
-            "name": "a-target",
-            "source": "a-source",
-            "write_mode": "merge",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "field", "target_property": "property"}
-            ],
-            "source_transformations": {
-                "limit": 0
-            }
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "source_transformations": {
+                                        "limit": 0
+                                    }
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerRelationshipTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerRelationshipTargetTest.java
@@ -1,0 +1,2342 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.neo4j.importer.v1.ImportSpecificationDeserializer.deserialize;
+
+import java.io.StringReader;
+import org.junit.Test;
+import org.neo4j.importer.v1.validation.InvalidSpecificationException;
+
+public class ImportSpecificationDeserializerRelationshipTargetTest {
+
+    @Test
+    public void fails_if_relationship_target_active_attribute_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "active": 42,
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].active: integer found, boolean expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_attribute_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0]: required property 'source' not found");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_attribute_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "type": "TYPE",
+            "source": 42,
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_attribute_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "type": "TYPE",
+            "source": "",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)", "$.targets.relationships[0].source: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_attribute_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "type": "TYPE",
+            "source": "   ",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_relationship_target_write_mode_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": 42,
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)", "$.targets.relationships[0].write_mode: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_write_mode_has_wrong_value() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": "not-a-valid-mode",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].write_mode: does not have a value in the enumeration [create, merge]");
+    }
+
+    @Test
+    public void fails_if_relationship_target_node_match_mode_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": "create",
+            "node_match_mode": 42,
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)", "$.targets.relationships[0].node_match_mode: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_node_match_mode_has_wrong_value() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": "create",
+            "node_match_mode": "not-a-valid-mode",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].node_match_mode: does not have a value in the enumeration [match, merge]");
+    }
+
+    @Test
+    public void fails_if_relationship_start_node_reference_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": "create",
+            "start_node_reference": 42,
+            "end_node_reference": "a-node-target"
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].start_node_reference: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_end_node_reference_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": "create",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": 42
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].end_node_reference: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_type_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ]
+        }]
+    }
+}
+"""
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)", "0 warning(s)", "$.targets.relationships[0]: required property 'type' not found");
+    }
+
+    @Test
+    public void fails_if_relationship_target_type_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "name": "a-node-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }],
+                        "relationships": [{
+                            "name": "a-relationship-target",
+                            "source": "a-source",
+                            "type": 42,
+                            "start_node_reference": "a-node-target",
+                            "end_node_reference": "a-node-target",
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].type: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_type_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "name": "a-node-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }],
+                        "relationships": [{
+                            "name": "a-relationship-target",
+                            "source": "a-source",
+                            "type": "",
+                            "start_node_reference": "a-node-target",
+                            "end_node_reference": "a-node-target",
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)", "$.targets.relationships[0].type: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_relationship_target_type_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "name": "a-node-target",
+                            "source": "a-source",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }],
+                        "relationships": [{
+                            "name": "a-relationship-target",
+                            "source": "a-source",
+                            "type": "   ",
+                            "start_node_reference": "a-node-target",
+                            "end_node_reference": "a-node-target",
+                            "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                            ]
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].type: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": 42
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        42
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_source_field_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"target_property": "id"}
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0]: required property 'source_field' not found");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_source_field_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+            {
+              "version": "1",
+              "sources": [{
+                "name": "a-source",
+                "type": "jdbc",
+                "data_source": "a-data-source",
+                "sql": "SELECT id, name FROM my.table"
+              }],
+              "targets": {
+                "nodes": [{
+                  "name": "a-node-target",
+                  "source": "a-source",
+                  "labels": ["Label"],
+                  "properties": [
+                    {"source_field": "id", "target_property": "id"}
+                  ]
+                }],
+                "relationships": [{
+                  "name": "a-relationship-target",
+                  "source": "a-source",
+                  "type": "TYPE",
+                  "start_node_reference": "a-node-target",
+                  "end_node_reference": "a-node-target",
+                  "properties": [
+                    {"source_field": 42, "target_property": "id"}
+                  ]
+                }]
+              }
+            }
+            """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0].source_field: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_source_field_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "", "target_property": "id"}
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0].source_field: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_source_field_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "   ", "target_property": "id"}
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0].source_field: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void does_not_fail_if_relationship_target_property_mappings_source_field_is_listed_in_target_aggregations() {
+        assertThatCode(() -> deserialize(new StringReader(
+                        """
+            {
+              "version": "1",
+              "sources": [{
+                "name": "a-source",
+                "type": "jdbc",
+                "data_source": "a-data-source",
+                "sql": "SELECT id, name FROM my.table"
+              }],
+              "targets": {
+                "nodes": [{
+                  "name": "a-node-target",
+                  "source": "a-source",
+                  "labels": ["Label"],
+                  "properties": [
+                    {"source_field": "id", "target_property": "id"}
+                  ]
+                }],
+                "relationships": [{
+                  "name": "a-relationship-target",
+                  "source": "a-source",
+                  "type": "TYPE",
+                  "start_node_reference": "a-node-target",
+                  "end_node_reference": "a-node-target",
+                  "source_transformations": {
+                    "aggregations": [{
+                        "field_name": "aggregated", "expression": "42"
+                    }]
+                  },
+                  "properties": [
+                    {"source_field": "aggregated", "target_property": "id"}
+                  ]
+                }]
+              }
+            }
+            """
+                                .stripIndent())))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_target_property_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id"}
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0]: required property 'target_property' not found");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_target_property_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+            {
+              "version": "1",
+              "sources": [{
+                "name": "a-source",
+                "type": "jdbc",
+                "data_source": "a-data-source",
+                "sql": "SELECT id, name FROM my.table"
+              }],
+              "targets": {
+                "nodes": [{
+                  "name": "a-node-target",
+                  "source": "a-source",
+                  "labels": ["Label"],
+                  "properties": [
+                    {"source_field": "id", "target_property": "id"}
+                  ]
+                }],
+                "relationships": [{
+                  "name": "a-relationship-target",
+                  "source": "a-source",
+                  "type": "TYPE",
+                  "start_node_reference": "a-node-target",
+                  "end_node_reference": "a-node-target",
+                  "properties": [
+                    {"source_field": "id", "target_property": 42}
+                  ]
+                }]
+              }
+            }
+            """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0].target_property: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_target_property_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": ""}
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0].target_property: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_target_property_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "   "}
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0].target_property: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_target_property_type_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id", "target_property_type": 42}
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0].target_property_type: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_property_mappings_target_property_type_is_unsupported() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id", "target_property_type": "blackhole"}
+                      ]
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].properties[0].target_property_type: does not have a value in the enumeration [boolean, boolean_array, byte_array, date, date_array, duration, duration_array, float, float_array, integer, integer_array, local_datetime, local_datetime_array, local_time, local_time_array, point, point_array, string, string_array, zoned_datetime, zoned_datetime_array, zoned_time, zoned_time_array]");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_enable_grouping_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                        "enable_grouping": 42
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.enable_grouping: integer found, boolean expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_have_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "aggregations": 42
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_element_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                        "aggregations": [42]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_expression_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                        "aggregations": [{
+                            "field_name": "field_2"
+                        }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0]: required property 'expression' not found");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_expression_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                        "aggregations": [{
+                            "expression": 42,
+                            "field_name": "field_2"
+                        }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0].expression: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_expression_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "aggregations": [{
+                              "expression": "",
+                              "field_name": "field_2"
+                          }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0].expression: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_expression_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "aggregations": [{
+                              "expression": "  ",
+                              "field_name": "field_2"
+                          }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0].expression: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_field_name_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                        "aggregations": [{
+                            "expression": "42"
+                        }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0]: required property 'field_name' not found");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_field_name_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                        "aggregations": [{
+                            "expression": "42",
+                            "field_name": 42
+                       }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0].field_name: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_field_name_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                         "aggregations": [{
+                             "expression": "42",
+                             "field_name": ""
+                         }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0].field_name: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_aggregations_field_name_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "aggregations": [{
+                              "expression": "42",
+                              "field_name": " "
+                          }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.aggregations[0].field_name: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_where_clause_has_wrong_type() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "where": 42
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.where: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_where_clause_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "where": ""
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.where: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_where_clause_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "where": "  "
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.where: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_order_by_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                        "order_by": 42
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.order_by: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_order_by_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "order_by": [42]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.order_by[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_order_by_expression_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                         "order_by": [{}]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.order_by[0]: required property 'expression' not found");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_order_by_expression_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                         "order_by": [{
+                             "expression": 42
+                         }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.order_by[0].expression: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_order_by_expression_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "order_by": [{
+                              "expression": ""
+                          }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.order_by[0].expression: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_order_by_expression_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "order_by": [{
+                              "expression": "   "
+                          }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.order_by[0].expression: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_order_by_order_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "order_by": [{
+                              "expression": "42",
+                              "order": 42
+                          }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.order_by[0].order: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_order_by_order_has_wrong_value() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "order_by": [{
+                              "expression": "42",
+                              "order": "new"
+                          }]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.order_by[0].order: does not have a value in the enumeration [ASC, DESC]");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_limit_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                        "limit": []
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.limit: array found, integer expected");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_limit_is_negative() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "limit": -42
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.limit: must have a minimum value of 1");
+    }
+
+    @Test
+    public void fails_if_relationship_target_source_transformation_limit_is_zero() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ]
+                    }],
+                    "relationships": [{
+                      "name": "a-relationship-target",
+                      "source": "a-source",
+                      "type": "TYPE",
+                      "start_node_reference": "a-node-target",
+                      "end_node_reference": "a-node-target",
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "source_transformations": {
+                          "limit": 0
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].source_transformations.limit: must have a minimum value of 1");
+    }
+}

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerRelationshipTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerRelationshipTargetTest.java
@@ -30,37 +30,37 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_active_attribute_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "active": 42,
-            "name": "a-relationship-target",
-            "source": "a-source",
-            "type": "TYPE",
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "active": 42,
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -73,35 +73,35 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_attribute_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "type": "TYPE",
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "type": "TYPE",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -114,36 +114,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_attribute_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "type": "TYPE",
-            "source": 42,
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "type": "TYPE",
+                                    "source": 42,
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -156,36 +156,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_attribute_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "type": "TYPE",
-            "source": "",
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "type": "TYPE",
+                                    "source": "",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -196,36 +196,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_attribute_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "type": "TYPE",
-            "source": "   ",
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "type": "TYPE",
+                                    "source": "   ",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -238,37 +238,37 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_write_mode_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "source": "a-source",
-            "type": "TYPE",
-            "write_mode": 42,
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "write_mode": 42,
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -279,37 +279,37 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_write_mode_has_wrong_value() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "source": "a-source",
-            "type": "TYPE",
-            "write_mode": "not-a-valid-mode",
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "write_mode": "not-a-valid-mode",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -322,38 +322,38 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_node_match_mode_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "source": "a-source",
-            "type": "TYPE",
-            "write_mode": "create",
-            "node_match_mode": 42,
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "write_mode": "create",
+                                    "node_match_mode": 42,
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -364,38 +364,38 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_node_match_mode_has_wrong_value() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "source": "a-source",
-            "type": "TYPE",
-            "write_mode": "create",
-            "node_match_mode": "not-a-valid-mode",
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "write_mode": "create",
+                                    "node_match_mode": "not-a-valid-mode",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -408,34 +408,34 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_start_node_reference_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "source": "a-source",
-            "type": "TYPE",
-            "write_mode": "create",
-            "start_node_reference": 42,
-            "end_node_reference": "a-node-target"
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "write_mode": "create",
+                                    "start_node_reference": 42,
+                                    "end_node_reference": "a-node-target"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -447,34 +447,34 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_end_node_reference_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "source": "a-source",
-            "type": "TYPE",
-            "write_mode": "create",
-            "start_node_reference": "a-node-target",
-            "end_node_reference": 42
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "write_mode": "create",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": 42
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -486,35 +486,35 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_type_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-{
-    "version": "1",
-    "sources": [{
-        "name": "a-source",
-        "type": "jdbc",
-        "data_source": "a-data-source",
-        "sql": "SELECT id, name FROM my.table"
-    }],
-    "targets": {
-        "nodes": [{
-            "name": "a-node-target",
-            "source": "a-source",
-            "labels": ["Label"],
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }],
-        "relationships": [{
-            "name": "a-relationship-target",
-            "source": "a-source",
-            "start_node_reference": "a-node-target",
-            "end_node_reference": "a-node-target",
-            "properties": [
-                {"source_field": "id", "target_property": "id"}
-            ]
-        }]
-    }
-}
-"""
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -525,36 +525,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_type_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "jdbc",
-                        "data_source": "a-data-source",
-                        "sql": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "name": "a-node-target",
-                            "source": "a-source",
-                            "labels": ["Label"],
-                            "properties": [
-                                {"source_field": "id", "target_property": "id"}
-                            ]
-                        }],
-                        "relationships": [{
-                            "name": "a-relationship-target",
-                            "source": "a-source",
-                            "type": 42,
-                            "start_node_reference": "a-node-target",
-                            "end_node_reference": "a-node-target",
-                            "properties": [
-                                {"source_field": "id", "target_property": "id"}
-                            ]
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": 42,
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -567,36 +567,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_type_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "jdbc",
-                        "data_source": "a-data-source",
-                        "sql": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "name": "a-node-target",
-                            "source": "a-source",
-                            "labels": ["Label"],
-                            "properties": [
-                                {"source_field": "id", "target_property": "id"}
-                            ]
-                        }],
-                        "relationships": [{
-                            "name": "a-relationship-target",
-                            "source": "a-source",
-                            "type": "",
-                            "start_node_reference": "a-node-target",
-                            "end_node_reference": "a-node-target",
-                            "properties": [
-                                {"source_field": "id", "target_property": "id"}
-                            ]
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -607,36 +607,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_type_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "jdbc",
-                        "data_source": "a-data-source",
-                        "sql": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "name": "a-node-target",
-                            "source": "a-source",
-                            "labels": ["Label"],
-                            "properties": [
-                                {"source_field": "id", "target_property": "id"}
-                            ]
-                        }],
-                        "relationships": [{
-                            "name": "a-relationship-target",
-                            "source": "a-source",
-                            "type": "   ",
-                            "start_node_reference": "a-node-target",
-                            "end_node_reference": "a-node-target",
-                            "properties": [
-                                {"source_field": "id", "target_property": "id"}
-                            ]
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "a-node-target",
+                                    "source": "a-source",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "a-relationship-target",
+                                    "source": "a-source",
+                                    "type": "   ",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target",
+                                    "properties": [
+                                        {"source_field": "id", "target_property": "id"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -649,34 +649,34 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": 42
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": 42
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -689,36 +689,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_element_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        42
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                42
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -731,36 +731,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_source_field_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"target_property": "id"}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"target_property": "id"}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -773,36 +773,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_source_field_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-            {
-              "version": "1",
-              "sources": [{
-                "name": "a-source",
-                "type": "jdbc",
-                "data_source": "a-data-source",
-                "sql": "SELECT id, name FROM my.table"
-              }],
-              "targets": {
-                "nodes": [{
-                  "name": "a-node-target",
-                  "source": "a-source",
-                  "labels": ["Label"],
-                  "properties": [
-                    {"source_field": "id", "target_property": "id"}
-                  ]
-                }],
-                "relationships": [{
-                  "name": "a-relationship-target",
-                  "source": "a-source",
-                  "type": "TYPE",
-                  "start_node_reference": "a-node-target",
-                  "end_node_reference": "a-node-target",
-                  "properties": [
-                    {"source_field": 42, "target_property": "id"}
-                  ]
-                }]
-              }
-            }
-            """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": 42, "target_property": "id"}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -815,36 +815,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_source_field_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "", "target_property": "id"}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "", "target_property": "id"}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -856,36 +856,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_source_field_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "   ", "target_property": "id"}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "   ", "target_property": "id"}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -898,41 +898,41 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void does_not_fail_if_relationship_target_property_mappings_source_field_is_listed_in_target_aggregations() {
         assertThatCode(() -> deserialize(new StringReader(
                         """
-            {
-              "version": "1",
-              "sources": [{
-                "name": "a-source",
-                "type": "jdbc",
-                "data_source": "a-data-source",
-                "sql": "SELECT id, name FROM my.table"
-              }],
-              "targets": {
-                "nodes": [{
-                  "name": "a-node-target",
-                  "source": "a-source",
-                  "labels": ["Label"],
-                  "properties": [
-                    {"source_field": "id", "target_property": "id"}
-                  ]
-                }],
-                "relationships": [{
-                  "name": "a-relationship-target",
-                  "source": "a-source",
-                  "type": "TYPE",
-                  "start_node_reference": "a-node-target",
-                  "end_node_reference": "a-node-target",
-                  "source_transformations": {
-                    "aggregations": [{
-                        "field_name": "aggregated", "expression": "42"
-                    }]
-                  },
-                  "properties": [
-                    {"source_field": "aggregated", "target_property": "id"}
-                  ]
-                }]
-              }
-            }
-            """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "source_transformations": {
+                                "aggregations": [{
+                                    "field_name": "aggregated", "expression": "42"
+                                }]
+                              },
+                              "properties": [
+                                {"source_field": "aggregated", "target_property": "id"}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .doesNotThrowAnyException();
     }
@@ -941,36 +941,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_target_property_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id"}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id"}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -983,36 +983,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_target_property_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-            {
-              "version": "1",
-              "sources": [{
-                "name": "a-source",
-                "type": "jdbc",
-                "data_source": "a-data-source",
-                "sql": "SELECT id, name FROM my.table"
-              }],
-              "targets": {
-                "nodes": [{
-                  "name": "a-node-target",
-                  "source": "a-source",
-                  "labels": ["Label"],
-                  "properties": [
-                    {"source_field": "id", "target_property": "id"}
-                  ]
-                }],
-                "relationships": [{
-                  "name": "a-relationship-target",
-                  "source": "a-source",
-                  "type": "TYPE",
-                  "start_node_reference": "a-node-target",
-                  "end_node_reference": "a-node-target",
-                  "properties": [
-                    {"source_field": "id", "target_property": 42}
-                  ]
-                }]
-              }
-            }
-            """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": 42}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1025,36 +1025,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_target_property_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": ""}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": ""}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1066,36 +1066,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_target_property_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "   "}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "   "}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1108,36 +1108,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_target_property_type_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id", "target_property_type": 42}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id", "target_property_type": 42}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1149,36 +1149,36 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_property_mappings_target_property_type_is_unsupported() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id", "target_property_type": "blackhole"}
-                      ]
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id", "target_property_type": "blackhole"}
+                              ]
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1191,39 +1191,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_enable_grouping_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                        "enable_grouping": 42
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                "enable_grouping": 42
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1236,39 +1236,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_have_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "aggregations": 42
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "aggregations": 42
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1281,39 +1281,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_element_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                        "aggregations": [42]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                "aggregations": [42]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1326,41 +1326,41 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_expression_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                        "aggregations": [{
-                            "field_name": "field_2"
-                        }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                "aggregations": [{
+                                    "field_name": "field_2"
+                                }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1373,42 +1373,42 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_expression_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                        "aggregations": [{
-                            "expression": 42,
-                            "field_name": "field_2"
-                        }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                "aggregations": [{
+                                    "expression": 42,
+                                    "field_name": "field_2"
+                                }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1421,42 +1421,42 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_expression_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "aggregations": [{
-                              "expression": "",
-                              "field_name": "field_2"
-                          }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "aggregations": [{
+                                      "expression": "",
+                                      "field_name": "field_2"
+                                  }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1468,42 +1468,42 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_expression_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "aggregations": [{
-                              "expression": "  ",
-                              "field_name": "field_2"
-                          }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "aggregations": [{
+                                      "expression": "  ",
+                                      "field_name": "field_2"
+                                  }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1516,41 +1516,41 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_field_name_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                        "aggregations": [{
-                            "expression": "42"
-                        }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                "aggregations": [{
+                                    "expression": "42"
+                                }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1563,42 +1563,42 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_field_name_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                        "aggregations": [{
-                            "expression": "42",
-                            "field_name": 42
-                       }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                "aggregations": [{
+                                    "expression": "42",
+                                    "field_name": 42
+                               }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1611,42 +1611,42 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_field_name_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                         "aggregations": [{
-                             "expression": "42",
-                             "field_name": ""
-                         }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                 "aggregations": [{
+                                     "expression": "42",
+                                     "field_name": ""
+                                 }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1658,42 +1658,42 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_aggregations_field_name_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "aggregations": [{
-                              "expression": "42",
-                              "field_name": " "
-                          }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "aggregations": [{
+                                      "expression": "42",
+                                      "field_name": " "
+                                  }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1706,39 +1706,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_where_clause_has_wrong_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "where": 42
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "where": 42
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1751,39 +1751,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_where_clause_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "where": ""
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "where": ""
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1795,39 +1795,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_where_clause_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "where": "  "
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "where": "  "
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1840,39 +1840,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_order_by_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                        "order_by": 42
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                "order_by": 42
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1885,39 +1885,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_order_by_element_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "order_by": [42]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "order_by": [42]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1930,39 +1930,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_order_by_expression_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                         "order_by": [{}]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                 "order_by": [{}]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -1975,41 +1975,41 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_order_by_expression_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                         "order_by": [{
-                             "expression": 42
-                         }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                 "order_by": [{
+                                     "expression": 42
+                                 }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -2022,41 +2022,41 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_order_by_expression_is_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "order_by": [{
-                              "expression": ""
-                          }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "order_by": [{
+                                      "expression": ""
+                                  }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -2068,41 +2068,41 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_order_by_expression_is_blank() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "order_by": [{
-                              "expression": "   "
-                          }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "order_by": [{
+                                      "expression": "   "
+                                  }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -2115,42 +2115,42 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_order_by_order_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "order_by": [{
-                              "expression": "42",
-                              "order": 42
-                          }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "order_by": [{
+                                      "expression": "42",
+                                      "order": 42
+                                  }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -2162,42 +2162,42 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_order_by_order_has_wrong_value() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "order_by": [{
-                              "expression": "42",
-                              "order": "new"
-                          }]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "order_by": [{
+                                      "expression": "42",
+                                      "order": "new"
+                                  }]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -2209,39 +2209,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_limit_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                        "limit": []
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                "limit": []
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -2254,39 +2254,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_limit_is_negative() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "limit": -42
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "limit": -42
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -2299,39 +2299,39 @@ public class ImportSpecificationDeserializerRelationshipTargetTest {
     public void fails_if_relationship_target_source_transformation_limit_is_zero() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ]
-                    }],
-                    "relationships": [{
-                      "name": "a-relationship-target",
-                      "source": "a-source",
-                      "type": "TYPE",
-                      "start_node_reference": "a-node-target",
-                      "end_node_reference": "a-node-target",
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "source_transformations": {
-                          "limit": 0
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ]
+                            }],
+                            "relationships": [{
+                              "name": "a-relationship-target",
+                              "source": "a-source",
+                              "type": "TYPE",
+                              "start_node_reference": "a-node-target",
+                              "end_node_reference": "a-node-target",
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "source_transformations": {
+                                  "limit": 0
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerSourceTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerSourceTest.java
@@ -39,21 +39,21 @@ public class ImportSpecificationDeserializerSourceTest {
     void fails_if_source_is_missing_type() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-        {
-            "version": "1",
-            "sources": [{
-                "name": "a-source",
-                "query": "SELECT id, name FROM my.table"
-            }],
-            "targets": {
-                "queries": [{
-                    "name": "a-target",
-                    "source": "a-source",
-                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                }]
-            }
-        }
-        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("0 warning(s)", "$.sources[0]: required property 'type' not found");
@@ -63,22 +63,22 @@ public class ImportSpecificationDeserializerSourceTest {
     void fails_if_source_type_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-        {
-            "version": "1",
-            "sources": [{
-                "name": "a-source",
-                "type": 42,
-                "query": "SELECT id, name FROM my.table"
-            }],
-            "targets": {
-                "queries": [{
-                    "name": "a-target",
-                    "source": "a-source",
-                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                }]
-            }
-        }
-        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": 42,
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("0 warning(s)", "$.sources[0].type: integer found, string expected");
@@ -88,22 +88,22 @@ public class ImportSpecificationDeserializerSourceTest {
     void fails_if_source_type_is_not_supported_by_any_loaded_source_provider() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-        {
-            "version": "1",
-            "sources": [{
-                "name": "a-source",
-                "type": "unsupported",
-                "query": "SELECT id, name FROM my.table"
-            }],
-            "targets": {
-                "queries": [{
-                    "name": "a-target",
-                    "source": "a-source",
-                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                }]
-            }
-        }
-        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "unsupported",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(UndeserializableSourceException.class)
                 .hasMessageContainingAll(
@@ -114,22 +114,22 @@ public class ImportSpecificationDeserializerSourceTest {
     void fails_if_third_party_source_and_supplier_do_not_match() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-        {
-            "version": "1",
-            "sources": [{
-                "name": "a-source",
-                "type": "jdbc",
-                "sql": "SELECT p.productname FROM products p ORDER BY p.productname ASC "
-            }],
-            "targets": {
-                "queries": [{
-                    "name": "a-target",
-                    "source": "a-source",
-                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                }]
-            }
-        }
-        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "sql": "SELECT p.productname FROM products p ORDER BY p.productname ASC "
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(UndeserializableSourceException.class)
                 .hasMessageContainingAll(

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -41,22 +41,22 @@ class ImportSpecificationDeserializerTest {
     void deserializes_minimal_job_spec() throws Exception {
         var json =
                 """
-            {
-                "version": "1",
-                "sources": [{
-                    "name": "my-bigquery-source",
-                    "type": "bigquery",
-                    "query": "SELECT id, name FROM my.table"
-                }],
-                "targets": {
-                    "queries": [{
-                        "name": "my-query",
-                        "source": "my-bigquery-source",
-                        "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                    }]
-                }
-            }
-        """
+                            {
+                                "version": "1",
+                                "sources": [{
+                                    "name": "my-bigquery-source",
+                                    "type": "bigquery",
+                                    "query": "SELECT id, name FROM my.table"
+                                }],
+                                "targets": {
+                                    "queries": [{
+                                        "name": "my-query",
+                                        "source": "my-bigquery-source",
+                                        "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                    }]
+                                }
+                            }
+                        """
                         .stripIndent();
 
         var spec = deserialize(new StringReader(json));
@@ -81,34 +81,34 @@ class ImportSpecificationDeserializerTest {
     void deserializes_job_spec() throws Exception {
         var json =
                 """
-            {
-                "version": "1",
-                "config": {
-                    "foo": "bar",
-                    "baz": 42,
-                    "qix": [true, 1.0, {}]
-                },
-                "sources": [{
-                    "name": "my-bigquery-source",
-                    "type": "bigquery",
-                    "query": "SELECT id, name FROM my.table"
-                }],
-                "targets": {
-                    "queries": [{
-                        "name": "my-query",
-                        "source": "my-bigquery-source",
-                        "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                    }]
-                },
-                "actions": [{
-                    "name": "my-http-get-action",
-                    "type": "http",
-                    "method": "get",
-                    "url": "https://example.com",
-                    "stage": "start"
-                }]
-            }
-        """
+                            {
+                                "version": "1",
+                                "config": {
+                                    "foo": "bar",
+                                    "baz": 42,
+                                    "qix": [true, 1.0, {}]
+                                },
+                                "sources": [{
+                                    "name": "my-bigquery-source",
+                                    "type": "bigquery",
+                                    "query": "SELECT id, name FROM my.table"
+                                }],
+                                "targets": {
+                                    "queries": [{
+                                        "name": "my-query",
+                                        "source": "my-bigquery-source",
+                                        "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                    }]
+                                },
+                                "actions": [{
+                                    "name": "my-http-get-action",
+                                    "type": "http",
+                                    "method": "get",
+                                    "url": "https://example.com",
+                                    "stage": "start"
+                                }]
+                            }
+                        """
                         .stripIndent();
 
         var spec = deserialize(new StringReader(json));
@@ -149,21 +149,21 @@ class ImportSpecificationDeserializerTest {
     void fails_if_version_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$: required property 'version' not found");
@@ -173,22 +173,22 @@ class ImportSpecificationDeserializerTest {
     void fails_if_version_is_invalid() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": [],
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": [],
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$.version: must be the constant value '1'");
@@ -198,17 +198,17 @@ class ImportSpecificationDeserializerTest {
     void fails_if_sources_are_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$: required property 'sources' not found");
@@ -218,18 +218,18 @@ class ImportSpecificationDeserializerTest {
     void fails_if_sources_are_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": 42,
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": 42,
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$.sources: integer found, array expected");
@@ -239,18 +239,18 @@ class ImportSpecificationDeserializerTest {
     void fails_if_source_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [42],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [42],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$.sources[0]: integer found, object expected");
@@ -260,18 +260,18 @@ class ImportSpecificationDeserializerTest {
     void fails_if_sources_are_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -282,15 +282,15 @@ class ImportSpecificationDeserializerTest {
     void fails_if_targets_are_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }]
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }]
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$: required property 'targets' not found");
@@ -300,16 +300,16 @@ class ImportSpecificationDeserializerTest {
     void fails_if_targets_are_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": 42
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": 42
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$.targets: integer found, object expected");
@@ -319,16 +319,16 @@ class ImportSpecificationDeserializerTest {
     void fails_if_targets_are_empty() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {}
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {}
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -343,18 +343,18 @@ class ImportSpecificationDeserializerTest {
     void fails_if_node_targets_are_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": 42
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": 42
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -365,18 +365,18 @@ class ImportSpecificationDeserializerTest {
     void fails_if_relationship_targets_are_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "relationships": 42
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "relationships": 42
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -387,18 +387,18 @@ class ImportSpecificationDeserializerTest {
     void fails_if_custom_query_targets_are_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": 42
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": 42
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -409,23 +409,23 @@ class ImportSpecificationDeserializerTest {
     void fails_if_actions_are_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    },
-                    "actions": 42
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            },
+                            "actions": 42
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$.actions: integer found, array expected");
@@ -435,23 +435,23 @@ class ImportSpecificationDeserializerTest {
     void fails_if_action_is_wrongly_typed() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    },
-                    "actions": [42]
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            },
+                            "actions": [42]
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll("1 error(s)", "0 warning(s)", "$.actions[0]: integer found, object expected");
@@ -461,21 +461,21 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_missing_in_source() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -486,26 +486,26 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_missing_in_node_target() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "source": "a-source",
-                            "write_mode": "merge",
-                            "labels": ["Label1", "Label2"],
-                            "properties": [
-                                {"source_field": "field_1", "target_property": "property1"},
-                                {"source_field": "field_2", "target_property": "property2"}
-                            ]
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label1", "Label2"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property1"},
+                                        {"source_field": "field_2", "target_property": "property2"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -516,35 +516,35 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_missing_in_relationship_target() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "source": "a-source",
-                            "name": "a-node-target",
-                            "write_mode": "merge",
-                            "labels": ["Label1", "Label2"],
-                            "properties": [
-                                {"source_field": "field_1", "target_property": "property1"},
-                                {"source_field": "field_2", "target_property": "property2"}
-                            ]
-                        }],
-                        "relationships": [{
-                            "source": "a-source",
-                            "type": "TYPE",
-                            "write_mode": "create",
-                            "node_match_mode": "match",
-                            "start_node_reference": "a-node-target",
-                            "end_node_reference": "a-node-target"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "source": "a-source",
+                                    "name": "a-node-target",
+                                    "write_mode": "merge",
+                                    "labels": ["Label1", "Label2"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property1"},
+                                        {"source_field": "field_2", "target_property": "property2"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "source": "a-source",
+                                    "type": "TYPE",
+                                    "write_mode": "create",
+                                    "node_match_mode": "match",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -555,21 +555,21 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_missing_in_custom_query_target() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -580,28 +580,28 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_missing_in_action() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    },
-                    "actions": [{
-                        "type": "http",
-                        "method": "get",
-                        "stage": "start",
-                        "url": "https://example.com"
-                    }]
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            },
+                            "actions": [{
+                                "type": "http",
+                                "method": "get",
+                                "stage": "start",
+                                "url": "https://example.com"
+                            }]
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -612,22 +612,22 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_blank_in_source() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "  ",
-                        "type": "bigquery",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "  ",
+                                "type": "bigquery",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -638,27 +638,27 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_blank_in_node_target() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "name": "  ",
-                            "source": "a-source",
-                            "labels": ["Label1", "Label2"],
-                            "write_mode": "create",
-                            "properties": [
-                                {"source_field": "field_1", "target_property": "property1"},
-                                {"source_field": "field_2", "target_property": "property2"}
-                            ]
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "name": "  ",
+                                    "source": "a-source",
+                                    "labels": ["Label1", "Label2"],
+                                    "write_mode": "create",
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property1"},
+                                        {"source_field": "field_2", "target_property": "property2"}
+                                    ]
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -669,36 +669,36 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_blank_in_relationship_target() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "source": "a-source",
-                            "name": "a-node-target",
-                            "write_mode": "merge",
-                            "labels": ["Label1", "Label2"],
-                            "properties": [
-                                {"source_field": "field_1", "target_property": "property1"},
-                                {"source_field": "field_2", "target_property": "property2"}
-                            ]
-                        }],
-                        "relationships": [{
-                            "name": "   ",
-                            "source": "a-source",
-                            "write_mode": "create",
-                            "node_match_mode": "merge",
-                            "type": "TYPE",
-                            "start_node_reference": "a-node-target",
-                            "end_node_reference": "a-node-target"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "source": "a-source",
+                                    "name": "a-node-target",
+                                    "write_mode": "merge",
+                                    "labels": ["Label1", "Label2"],
+                                    "properties": [
+                                        {"source_field": "field_1", "target_property": "property1"},
+                                        {"source_field": "field_2", "target_property": "property2"}
+                                    ]
+                                }],
+                                "relationships": [{
+                                    "name": "   ",
+                                    "source": "a-source",
+                                    "write_mode": "create",
+                                    "node_match_mode": "merge",
+                                    "type": "TYPE",
+                                    "start_node_reference": "a-node-target",
+                                    "end_node_reference": "a-node-target"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -711,22 +711,22 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_blank_in_custom_query_target() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "   ",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    }
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "   ",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -739,29 +739,29 @@ class ImportSpecificationDeserializerTest {
     void fails_if_name_is_blank_in_action() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "type": "bigquery",
-                        "name": "a-source",
-                        "query": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "queries": [{
-                            "name": "a-target",
-                            "source": "a-source",
-                            "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
-                        }]
-                    },
-                    "actions": [{
-                        "name": "   ",
-                        "type": "http",
-                        "method": "get",
-                        "stage": "post_nodes",
-                        "url": "https://example.com"
-                    }]
-                }
-                """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "type": "bigquery",
+                                "name": "a-source",
+                                "query": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "queries": [{
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "query": "UNWIND $rows AS row CREATE (n:ANode) SET n = row"
+                                }]
+                            },
+                            "actions": [{
+                                "name": "   ",
+                                "type": "http",
+                                "method": "get",
+                                "stage": "post_nodes",
+                                "url": "https://example.com"
+                            }]
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(


### PR DESCRIPTION
This covers everything but the schema section.

This commit also moves some existing tests to the correct test class. Some tests were indeed exercising the built-in validators but were part of the test class focusing on JSON schema.