### PR TITLE
feat: validate node key constraints

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInKeyConstraintValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInKeyConstraintValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingLabelInKeyConstraintValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-008";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingLabelInKeyConstraintValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.key_constraints", index);
+        var labels = target.getLabels();
+        var keyConstraints = schema.getKeyConstraints();
+        for (int i = 0; i < keyConstraints.size(); i++) {
+            var label = keyConstraints.get(i).getLabel();
+            if (!labels.contains(label)) {
+                var path = String.format("%s[%d].label", basePath, i);
+                invalidPaths.put(path, label);
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusLabel) -> builder.addError(
+                path, ERROR_CODE, String.format("%s \"%s\" is not part of the defined labels", path, bogusLabel)));
+        return !invalidPaths.isEmpty();
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInKeyConstraintValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInKeyConstraintValidator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.PropertyMapping;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingPropertyInKeyConstraintValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-007";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingPropertyInKeyConstraintValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.key_constraints", index);
+        var properties = propertiesOf(target);
+        var keyConstraints = schema.getKeyConstraints();
+        for (int i = 0; i < keyConstraints.size(); i++) {
+            var actualProperties = keyConstraints.get(i).getProperties();
+            for (int j = 0; j < actualProperties.size(); j++) {
+                String property = actualProperties.get(j);
+                if (!properties.contains(property)) {
+                    var path = String.format("%s[%d].properties[%d]", basePath, i, j);
+                    invalidPaths.put(path, property);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusProperty) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format("%s \"%s\" is not part of the property mappings", path, bogusProperty)));
+        return !invalidPaths.isEmpty();
+    }
+
+    private static Set<String> propertiesOf(EntityTarget target) {
+        return target.getProperties().stream()
+                .map(PropertyMapping::getTargetProperty)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -1,9 +1,12 @@
+# keep this alphabetically sorted
 org.neo4j.importer.v1.validation.plugin.AtLeastOneActiveTargetValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingActiveNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingDependsOnValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInKeyConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInUniqueConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingNodeReferenceValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInKeyConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInUniqueConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingSourceValidator

--- a/src/main/resources/spec.v1.json
+++ b/src/main/resources/spec.v1.json
@@ -655,17 +655,20 @@
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "label": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "properties": {
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S+"
           },
           "minItems": 1
         },

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -1612,7 +1612,7 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     }
 
     @Test
-    public void fails_if_node_target_type_constraint_refer_to_non_existent_property() {
+    public void fails_if_node_target_type_constraint_refers_to_non_existent_property() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
                         {
@@ -1649,7 +1649,7 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     }
 
     @Test
-    public void fails_if_node_target_type_constraint_refer_to_non_existent_label() {
+    public void fails_if_node_target_type_constraint_refers_to_non_existent_label() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
                         {
@@ -1794,5 +1794,79 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                         "1 error(s)",
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.unique_constraints[0].label \"Invalid\" is not part of the defined labels");
+    }
+
+    @Test
+    public void fails_if_node_target_key_constraint_refers_to_non_existent_property() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "schema": {
+                                "key_constraints": [
+                                    {"name": "a key constraint", "label": "Label", "properties": ["invalid"]}
+                                ]
+                              }
+                            }]
+                          }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].properties[0] \"invalid\" is not part of the property mappings");
+    }
+
+    @Test
+    public void fails_if_node_target_key_constraint_refers_to_non_existent_label() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "schema": {
+                                "key_constraints": [
+                                    {"name": "a key constraint", "label": "Invalid", "properties": ["id"]}
+                                ]
+                              }
+                            }]
+                          }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].label \"Invalid\" is not part of the defined labels");
     }
 }

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -3065,4 +3065,660 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.unique_constraints[0].options: integer found, object expected");
     }
+
+    @Test
+    public void fails_if_node_schema_key_constraints_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": 42
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraints_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [42]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_name_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"label": "Label", "properties": ["property"]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0]: required property 'name' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_name_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": 42, "label": "Label", "properties": ["property"]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].name: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_name_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "", "label": "Label", "properties": ["property"]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].name: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_name_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "   ", "label": "Label", "properties": ["property"]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].name: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_label_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "properties": ["property"]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0]: required property 'label' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_label_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": 42, "properties": ["property"]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].label: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_label_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "", "properties": ["property"]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].label: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_label_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "   ", "properties": ["property"]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].label: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_properties_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "Label"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0]: required property 'properties' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_properties_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "Label", "properties": 42}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].properties: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_properties_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "Label", "properties": []}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].properties: must have at least 1 items but found 0");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_properties_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "Label", "properties": [42]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].properties[0]: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_properties_element_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "Label", "properties": [""]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].properties[0]: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_properties_element_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "Label", "properties": ["   "]}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].properties[0]: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_key_constraint_options_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "key_constraints": [
+                                            {"name": "a key constraint", "label": "Label", "properties": ["property"], options: 42}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints[0].options: integer found, object expected");
+    }
 }


### PR DESCRIPTION
This adds coverage for the key constraints of the node schema section of the spec.

Stacked on top of https://github.com/neo4j/import-spec/pull/72.