### PR TITLE
feat: add coverage for node existence constraint

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInExistenceConstraintValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInExistenceConstraintValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingLabelInExistenceConstraintValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-010";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingLabelInExistenceConstraintValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.existence_constraints", index);
+        var labels = target.getLabels();
+        var existenceConstraints = schema.getExistenceConstraints();
+        for (int i = 0; i < existenceConstraints.size(); i++) {
+            var label = existenceConstraints.get(i).getLabel();
+            if (!labels.contains(label)) {
+                var path = String.format("%s[%d].label", basePath, i);
+                invalidPaths.put(path, label);
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusLabel) -> builder.addError(
+                path, ERROR_CODE, String.format("%s \"%s\" is not part of the defined labels", path, bogusLabel)));
+        return !invalidPaths.isEmpty();
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInExistenceConstraintValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInExistenceConstraintValidator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.PropertyMapping;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingPropertyInExistenceConstraintValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-009";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingPropertyInExistenceConstraintValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.existence_constraints", index);
+        var properties = propertiesOf(target);
+        var existenceConstraints = schema.getExistenceConstraints();
+        for (int i = 0; i < existenceConstraints.size(); i++) {
+            var property = existenceConstraints.get(i).getProperty();
+            if (!properties.contains(property)) {
+                var path = String.format("%s[%d].property", basePath, i);
+                invalidPaths.put(path, property);
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusProperty) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format("%s \"%s\" is not part of the property mappings", path, bogusProperty)));
+        return !invalidPaths.isEmpty();
+    }
+
+    private static Set<String> propertiesOf(EntityTarget target) {
+        return target.getProperties().stream()
+                .map(PropertyMapping::getTargetProperty)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -2,10 +2,12 @@
 org.neo4j.importer.v1.validation.plugin.AtLeastOneActiveTargetValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingActiveNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingDependsOnValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInExistenceConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInKeyConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInUniqueConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingNodeReferenceValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInExistenceConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInKeyConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInUniqueConstraintValidator

--- a/src/main/resources/spec.v1.json
+++ b/src/main/resources/spec.v1.json
@@ -721,14 +721,18 @@
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "label": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "property": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S+"
         }
       },
       "required": [

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -1869,4 +1869,78 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.key_constraints[0].label \"Invalid\" is not part of the defined labels");
     }
+
+    @Test
+    public void fails_if_node_target_existence_constraint_refer_to_non_existent_label() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "schema": {
+                        "existence_constraints": [
+                            {"name": "a type constraint", "label": "Invalid", "property": "id"}
+                        ]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].label \"Invalid\" is not part of the defined labels");
+    }
+
+    @Test
+    public void fails_if_node_target_existence_constraint_property_refers_to_non_existent_property() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "schema": {
+                        "existence_constraints": [
+                            {"name": "a type constraint", "label": "Label", "property": "invalid"}
+                        ]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].property \"invalid\" is not part of the property mappings");
+    }
 }

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -1872,80 +1872,6 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     }
 
     @Test
-    public void fails_if_node_schema_type_constraints_is_wrongly_typed() {
-        assertThatThrownBy(() -> deserialize(new StringReader(
-                        """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "jdbc",
-                        "data_source": "a-data-source",
-                        "sql": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "active": true,
-                            "name": "a-target",
-                            "source": "a-source",
-                            "write_mode": "merge",
-                            "labels": ["Label"],
-                            "properties": [
-                                {"source_field": "field", "target_property": "property"}
-                            ],
-                            "schema": {
-                                "type_constraints": 42
-                            }
-                        }]
-                    }
-                }
-                """
-                                .stripIndent())))
-                .isInstanceOf(InvalidSpecificationException.class)
-                .hasMessageContainingAll(
-                        "1 error(s)",
-                        "0 warning(s)",
-                        "$.targets.nodes[0].schema.type_constraints: integer found, array expected");
-    }
-
-    @Test
-    public void fails_if_node_schema_type_constraints_element_is_wrongly_typed() {
-        assertThatThrownBy(() -> deserialize(new StringReader(
-                        """
-                {
-                    "version": "1",
-                    "sources": [{
-                        "name": "a-source",
-                        "type": "jdbc",
-                        "data_source": "a-data-source",
-                        "sql": "SELECT id, name FROM my.table"
-                    }],
-                    "targets": {
-                        "nodes": [{
-                            "active": true,
-                            "name": "a-target",
-                            "source": "a-source",
-                            "write_mode": "merge",
-                            "labels": ["Label"],
-                            "properties": [
-                                {"source_field": "field", "target_property": "property"}
-                            ],
-                            "schema": {
-                                "type_constraints": [42]
-                            }
-                        }]
-                    }
-                }
-                """
-                                .stripIndent())))
-                .isInstanceOf(InvalidSpecificationException.class)
-                .hasMessageContainingAll(
-                        "1 error(s)",
-                        "0 warning(s)",
-                        "$.targets.nodes[0].schema.type_constraints[0]: integer found, object expected");
-    }
-
-    @Test
     public void fails_if_node_schema_type_constraint_name_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
@@ -2408,6 +2334,545 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                         "1 error(s)",
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.type_constraints[0].property: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraints_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "type_constraints": 42
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.type_constraints: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraints_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "type_constraints": [42]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.type_constraints[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_name_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"label": "Label", "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0]: required property 'name' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_name_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": 42, "label": "Label", "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].name: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_name_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "", "label": "Label", "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].name: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_name_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "   ", "label": "Label", "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].name: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_label_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "a type constraint", "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0]: required property 'label' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_label_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "a type constraint", "label": 42, "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].label: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_label_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "a type constraint", "label": "", "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].label: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_label_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "a type constraint", "label": "  ", "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].label: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_property_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "a type constraint", "label": "Label"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0]: required property 'property' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_property_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "a type constraint", "label": "Label", "property": 42}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].property: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_property_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "a type constraint", "label": "Label", "property": ""}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].property: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_existence_constraint_property_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "existence_constraints": [
+                                            {"name": "a type constraint", "label": "Label", "property": "   "}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.existence_constraints[0].property: does not match the regex pattern \\S+");
     }
 
     @Test


### PR DESCRIPTION
This adds coverage for the existence constraints of the node schema section of the spec.