### PR TITLE
feat: add coverage for node text indexes

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInTextIndexValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInTextIndexValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingLabelInTextIndexValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-015";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingLabelInTextIndexValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.text_indexes", index);
+        var labels = target.getLabels();
+        var textIndexes = schema.getTextIndexes();
+        for (int i = 0; i < textIndexes.size(); i++) {
+            var label = textIndexes.get(i).getLabel();
+            if (!labels.contains(label)) {
+                var path = String.format("%s[%d].label", basePath, i);
+                invalidPaths.put(path, label);
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusLabel) -> builder.addError(
+                path, ERROR_CODE, String.format("%s \"%s\" is not part of the defined labels", path, bogusLabel)));
+        return !invalidPaths.isEmpty();
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInTextIndexValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInTextIndexValidator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.PropertyMapping;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingPropertyInTextIndexValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-016";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingPropertyInTextIndexValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.text_indexes", index);
+        var properties = propertiesOf(target);
+        var textIndexes = schema.getTextIndexes();
+        for (int i = 0; i < textIndexes.size(); i++) {
+            var property = textIndexes.get(i).getProperty();
+            if (!properties.contains(property)) {
+                var path = String.format("%s[%d].property", basePath, i);
+                invalidPaths.put(path, property);
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusProperty) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format("%s \"%s\" is not part of the property mappings", path, bogusProperty)));
+        return !invalidPaths.isEmpty();
+    }
+
+    private static Set<String> propertiesOf(EntityTarget target) {
+        return target.getProperties().stream()
+                .map(PropertyMapping::getTargetProperty)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -5,12 +5,14 @@ org.neo4j.importer.v1.validation.plugin.NoDanglingDependsOnValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInExistenceConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInKeyConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInRangeIndexValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInTextIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInUniqueConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInExistenceConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInKeyConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInRangeIndexValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInTextIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInUniqueConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingSourceValidator

--- a/src/main/resources/spec.v1.json
+++ b/src/main/resources/spec.v1.json
@@ -777,15 +777,18 @@
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "label": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "property": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "options": {
           "type": "object"

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -1871,7 +1871,7 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     }
 
     @Test
-    public void fails_if_node_target_existence_constraint_refer_to_non_existent_label() {
+    public void fails_if_node_target_existence_constraint_refers_to_non_existent_label() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
                 {
@@ -1945,7 +1945,7 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     }
 
     @Test
-    public void fails_if_node_target_range_index_refer_to_non_existent_label() {
+    public void fails_if_node_target_range_index_refers_to_non_existent_label() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
                 {

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -2017,4 +2017,78 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.range_indexes[0].properties[0] \"invalid\" is not part of the property mappings");
     }
+
+    @Test
+    public void fails_if_node_target_text_index_refers_to_non_existent_label() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "schema": {
+                        "text_indexes": [
+                            {"name": "a text index", "label": "Invalid", "property": "id"}
+                        ]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].label \"Invalid\" is not part of the defined labels");
+    }
+
+    @Test
+    public void fails_if_node_target_text_index_property_refers_to_non_existent_property() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "schema": {
+                        "text_indexes": [
+                            {"name": "a text index", "label": "Label", "property": "invalid"}
+                        ]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].property \"invalid\" is not part of the property mappings");
+    }
 }

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -4980,7 +4980,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "", "label": "Label", "properties": ["property"]}
+                                    {"name": "", "label": "Label", "property": "property"}
                                 ]
                             }
                         }]
@@ -5135,7 +5135,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a text index", "label": "", "properties": ["property"]}
+                                    {"name": "a text index", "label": "", "property": "property"}
                                 ]
                             }
                         }]
@@ -5189,7 +5189,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
     }
 
     @Test
-    public void fails_if_node_schema_text_index_properties_is_missing() {
+    public void fails_if_node_schema_text_index_property_is_missing() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
                 {

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -5057,7 +5057,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "property": "property"}
+                                    {"name": "a text index", "property": "property"}
                                 ]
                             }
                         }]
@@ -5096,7 +5096,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "label": 42, "property": "property"}
+                                    {"name": "a text index", "label": 42, "property": "property"}
                                 ]
                             }
                         }]
@@ -5135,7 +5135,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "label": "", "properties": ["property"]}
+                                    {"name": "a text index", "label": "", "properties": ["property"]}
                                 ]
                             }
                         }]
@@ -5173,7 +5173,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "label": "   ", "property": "property"}
+                                    {"name": "a text index", "label": "   ", "property": "property"}
                                 ]
                             }
                         }]
@@ -5212,7 +5212,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "label": "Label"}
+                                    {"name": "a text index", "label": "Label"}
                                 ]
                             }
                         }]
@@ -5251,7 +5251,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "label": "Label", "property": 42}
+                                    {"name": "a text index", "label": "Label", "property": 42}
                                 ]
                             }
                         }]
@@ -5290,7 +5290,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "label": "Label", "property": ""}
+                                    {"name": "a text index", "label": "Label", "property": ""}
                                 ]
                             }
                         }]
@@ -5328,7 +5328,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "label": "Label", "property": "   "}
+                                    {"name": "a text index", "label": "Label", "property": "   "}
                                 ]
                             }
                         }]
@@ -5367,7 +5367,7 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                             ],
                             "schema": {
                                 "text_indexes": [
-                                    {"name": "a key constraint", "label": "Label", "property": "property", "options": 42}
+                                    {"name": "a text index", "label": "Label", "property": "property", "options": 42}
                                 ]
                             }
                         }]

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -4803,4 +4803,582 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.range_indexes[0].properties[0]: does not match the regex pattern \\S+");
     }
+
+    @Test
+    public void fails_if_node_schema_text_indexes_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": 42
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_indexes_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [42]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_name_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"label": "Label", "property": "property"}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0]: required property 'name' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_name_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": 42, "label": "Label", "property": "property"}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].name: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_name_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "", "label": "Label", "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].name: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_name_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "   ", "label": "Label", "property": "property"}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].name: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_label_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "property": "property"}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0]: required property 'label' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_label_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "label": 42, "property": "property"}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].label: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_label_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "label": "", "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].label: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_label_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "label": "   ", "property": "property"}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].label: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_properties_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "label": "Label"}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0]: required property 'property' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_property_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "label": "Label", "property": 42}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].property: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_property_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "label": "Label", "property": ""}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].property: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_property_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "label": "Label", "property": "   "}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].property: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_text_index_options_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "text_indexes": [
+                                    {"name": "a key constraint", "label": "Label", "property": "property", "options": 42}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.text_indexes[0].options: integer found, object expected");
+    }
 }


### PR DESCRIPTION
This adds coverage for the text indexes of the node schema section of the spec.