### PR TITLE
feat: add coverage for node full text indexes

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInFullTextIndexValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInFullTextIndexValidator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingLabelInFullTextIndexValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-019";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingLabelInFullTextIndexValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.fulltext_indexes", index);
+        var labels = target.getLabels();
+        var fullTextIndexes = schema.getFullTextIndexes();
+        for (int i = 0; i < fullTextIndexes.size(); i++) {
+            var indexLabels = fullTextIndexes.get(i).getLabels();
+            for (int j = 0; j < indexLabels.size(); j++) {
+                var label = indexLabels.get(j);
+                if (!labels.contains(label)) {
+                    var path = String.format("%s[%d].labels[%d]", basePath, i, j);
+                    invalidPaths.put(path, label);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusLabel) -> builder.addError(
+                path, ERROR_CODE, String.format("%s \"%s\" is not part of the defined labels", path, bogusLabel)));
+        return !invalidPaths.isEmpty();
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInFullTextIndexValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInFullTextIndexValidator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.PropertyMapping;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingPropertyInFullTextIndexValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-020";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingPropertyInFullTextIndexValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.fulltext_indexes", index);
+        var properties = propertiesOf(target);
+        var fullTextIndexes = schema.getFullTextIndexes();
+        for (int i = 0; i < fullTextIndexes.size(); i++) {
+            var indexProperties = fullTextIndexes.get(i).getProperties();
+            for (int j = 0; j < indexProperties.size(); j++) {
+                var property = indexProperties.get(j);
+                if (!properties.contains(property)) {
+                    var path = String.format("%s[%d].properties[%d]", basePath, i, j);
+                    invalidPaths.put(path, property);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusProperty) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format("%s \"%s\" is not part of the property mappings", path, bogusProperty)));
+        return !invalidPaths.isEmpty();
+    }
+
+    private static Set<String> propertiesOf(EntityTarget target) {
+        return target.getProperties().stream()
+                .map(PropertyMapping::getTargetProperty)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -3,6 +3,7 @@ org.neo4j.importer.v1.validation.plugin.AtLeastOneActiveTargetValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingActiveNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingDependsOnValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInExistenceConstraintValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInFullTextIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInKeyConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInPointIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInRangeIndexValidator
@@ -11,6 +12,7 @@ org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInUniqueConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInExistenceConstraintValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInFullTextIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInKeyConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInPointIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInRangeIndexValidator

--- a/src/main/resources/spec.v1.json
+++ b/src/main/resources/spec.v1.json
@@ -835,13 +835,15 @@
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "labels": {
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S+"
           },
           "minItems": 1
         },
@@ -849,7 +851,8 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S+"
           },
           "minItems": 1
         },

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -2169,33 +2169,33 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     @Test
     public void fails_if_node_target_fulltext_index_refers_to_non_existent_label() {
         assertThatThrownBy(() -> deserialize(new StringReader(
+                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a full text index", "labels": ["Invalid"], "properties": ["id"]}
+                                ]
+                              }
+                            }]
+                          }
+                        }
                         """
-        {
-          "version": "1",
-          "sources": [{
-            "name": "a-source",
-            "type": "jdbc",
-            "data_source": "a-data-source",
-            "sql": "SELECT id, name FROM my.table"
-          }],
-          "targets": {
-            "nodes": [{
-              "name": "a-node-target",
-              "source": "a-source",
-              "labels": ["Label"],
-              "properties": [
-                {"source_field": "id", "target_property": "id"}
-              ],
-              "schema": {
-                "fulltext_indexes": [
-                    {"name": "a type constraint", "labels": ["Invalid"], "properties": ["id"]}
-                ]
-              }
-            }]
-          }
-        }
-        """
-                                .stripIndent())))
+                        .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
                         "1 error(s)",
@@ -2206,33 +2206,33 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     @Test
     public void fails_if_node_target_fulltext_index_property_refers_to_non_existent_property() {
         assertThatThrownBy(() -> deserialize(new StringReader(
+                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a full text index", "labels": ["Label"], "properties": ["invalid"]}
+                                ]
+                              }
+                            }]
+                          }
+                        }
                         """
-        {
-          "version": "1",
-          "sources": [{
-            "name": "a-source",
-            "type": "jdbc",
-            "data_source": "a-data-source",
-            "sql": "SELECT id, name FROM my.table"
-          }],
-          "targets": {
-            "nodes": [{
-              "name": "a-node-target",
-              "source": "a-source",
-              "labels": ["Label"],
-              "properties": [
-                {"source_field": "id", "target_property": "id"}
-              ],
-              "schema": {
-                "fulltext_indexes": [
-                    {"name": "a type constraint", "labels": ["Label"], "properties": ["invalid"]}
-                ]
-              }
-            }]
-          }
-        }
-        """
-                                .stripIndent())))
+                        .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
                         "1 error(s)",

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -2169,7 +2169,7 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     @Test
     public void fails_if_node_target_fulltext_index_refers_to_non_existent_label() {
         assertThatThrownBy(() -> deserialize(new StringReader(
-                """
+                        """
                         {
                           "version": "1",
                           "sources": [{
@@ -2195,7 +2195,7 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                           }
                         }
                         """
-                        .stripIndent())))
+                                .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
                         "1 error(s)",
@@ -2206,7 +2206,7 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     @Test
     public void fails_if_node_target_fulltext_index_property_refers_to_non_existent_property() {
         assertThatThrownBy(() -> deserialize(new StringReader(
-                """
+                        """
                         {
                           "version": "1",
                           "sources": [{
@@ -2232,7 +2232,7 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                           }
                         }
                         """
-                        .stripIndent())))
+                                .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
                         "1 error(s)",

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -2165,4 +2165,78 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.point_indexes[0].property \"invalid\" is not part of the property mappings");
     }
+
+    @Test
+    public void fails_if_node_target_fulltext_index_refers_to_non_existent_label() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+        {
+          "version": "1",
+          "sources": [{
+            "name": "a-source",
+            "type": "jdbc",
+            "data_source": "a-data-source",
+            "sql": "SELECT id, name FROM my.table"
+          }],
+          "targets": {
+            "nodes": [{
+              "name": "a-node-target",
+              "source": "a-source",
+              "labels": ["Label"],
+              "properties": [
+                {"source_field": "id", "target_property": "id"}
+              ],
+              "schema": {
+                "fulltext_indexes": [
+                    {"name": "a type constraint", "labels": ["Invalid"], "properties": ["id"]}
+                ]
+              }
+            }]
+          }
+        }
+        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].labels[0] \"Invalid\" is not part of the defined labels");
+    }
+
+    @Test
+    public void fails_if_node_target_fulltext_index_property_refers_to_non_existent_property() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+        {
+          "version": "1",
+          "sources": [{
+            "name": "a-source",
+            "type": "jdbc",
+            "data_source": "a-data-source",
+            "sql": "SELECT id, name FROM my.table"
+          }],
+          "targets": {
+            "nodes": [{
+              "name": "a-node-target",
+              "source": "a-source",
+              "labels": ["Label"],
+              "properties": [
+                {"source_field": "id", "target_property": "id"}
+              ],
+              "schema": {
+                "fulltext_indexes": [
+                    {"name": "a type constraint", "labels": ["Label"], "properties": ["invalid"]}
+                ]
+              }
+            }]
+          }
+        }
+        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].properties[0] \"invalid\" is not part of the property mappings");
+    }
 }

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -5959,4 +5959,660 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.point_indexes[0].options: integer found, object expected");
     }
+
+    @Test
+    public void fails_if_node_schema_fulltext_indexes_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": 42
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_indexes_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [42]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_name_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"labels": ["Label"], "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0]: required property 'name' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_name_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": 42, "labels": ["Label"], "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].name: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_name_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "", "labels": ["Label"], "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].name: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_name_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "   ", "labels": ["Label"], "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].name: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_labels_are_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0]: required property 'labels' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_labels_are_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": 42, "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].labels: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_labels_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": [42], "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].labels[0]: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_labels_element_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": [""], "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].labels[0]: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_labels_element_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": ["   "], "properties": ["property"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].labels[0]: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_properties_are_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": ["Label"]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0]: required property 'properties' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_properties_are_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": ["Label"], "properties": 42}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].properties: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_properties_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": ["Label"], "properties": [42]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].properties[0]: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_properties_element_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": ["Label"], "properties": [""]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].properties[0]: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_properties_element_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": ["Label"], "properties": ["   "]}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].properties[0]: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_fulltext_index_options_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                    "version": "1",
+                    "sources": [{
+                        "name": "a-source",
+                        "type": "jdbc",
+                        "data_source": "a-data-source",
+                        "sql": "SELECT id, name FROM my.table"
+                    }],
+                    "targets": {
+                        "nodes": [{
+                            "active": true,
+                            "name": "a-target",
+                            "source": "a-source",
+                            "write_mode": "merge",
+                            "labels": ["Label"],
+                            "properties": [
+                                {"source_field": "field", "target_property": "property"}
+                            ],
+                            "schema": {
+                                "fulltext_indexes": [
+                                    {"name": "a fulltext index", "labels": ["Label"], "properties": ["property"], "options": 42}
+                                ]
+                            }
+                        }]
+                    }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.fulltext_indexes[0].options: integer found, object expected");
+    }
 }


### PR DESCRIPTION
This adds coverage for the full text indexes of the node schema section of the spec.