### PR TITLE
feat: add coverage for node vector indexes

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInVectorIndexValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingLabelInVectorIndexValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingLabelInVectorIndexValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-021";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingLabelInVectorIndexValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.vector_indexes", index);
+        var labels = target.getLabels();
+        var vectorIndexes = schema.getVectorIndexes();
+        for (int i = 0; i < vectorIndexes.size(); i++) {
+            var label = vectorIndexes.get(i).getLabel();
+            if (!labels.contains(label)) {
+                var path = String.format("%s[%d].label", basePath, i);
+                invalidPaths.put(path, label);
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusLabel) -> builder.addError(
+                path, ERROR_CODE, String.format("%s \"%s\" is not part of the defined labels", path, bogusLabel)));
+        return !invalidPaths.isEmpty();
+    }
+}

--- a/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInVectorIndexValidator.java
+++ b/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDanglingPropertyInVectorIndexValidator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.PropertyMapping;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoDanglingPropertyInVectorIndexValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DANG-022";
+
+    private final Map<String, String> invalidPaths;
+
+    public NoDanglingPropertyInVectorIndexValidator() {
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var schema = target.getSchema();
+        if (schema == null) {
+            return;
+        }
+        var basePath = String.format("$.targets.nodes[%d].schema.vector_indexes", index);
+        var properties = propertiesOf(target);
+        var vectorIndexes = schema.getVectorIndexes();
+        for (int i = 0; i < vectorIndexes.size(); i++) {
+            var vectorIndex = vectorIndexes.get(i);
+            var property = vectorIndex.getProperty();
+            if (!properties.contains(property)) {
+                var path = String.format("%s[%d].property", basePath, i);
+                invalidPaths.put(path, property);
+            }
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((path, bogusProperty) -> builder.addError(
+                path,
+                ERROR_CODE,
+                String.format("%s \"%s\" is not part of the property mappings", path, bogusProperty)));
+        return !invalidPaths.isEmpty();
+    }
+
+    private static Set<String> propertiesOf(EntityTarget target) {
+        return target.getProperties().stream()
+                .map(PropertyMapping::getTargetProperty)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -10,6 +10,7 @@ org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInRangeIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInTextIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInUniqueConstraintValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingLabelInVectorIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInExistenceConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInFullTextIndexValidator
@@ -19,6 +20,7 @@ org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInRangeIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInTextIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInUniqueConstraintValidator
+org.neo4j.importer.v1.validation.plugin.NoDanglingPropertyInVectorIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingSourceValidator
 org.neo4j.importer.v1.validation.plugin.NoDependencyCycleValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedAggregateFieldNameValidator

--- a/src/main/resources/spec.v1.json
+++ b/src/main/resources/spec.v1.json
@@ -872,15 +872,18 @@
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "label": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "property": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S+"
         },
         "options": {
           "type": "object"

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -2244,31 +2244,31 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     public void fails_if_node_target_vector_index_refers_to_non_existent_label() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "schema": {
-                        "vector_indexes": [
-                            {"name": "a text index", "label": "Invalid", "property": "id", "options": {}}
-                        ]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "schema": {
+                                "vector_indexes": [
+                                    {"name": "a vector index", "label": "Invalid", "property": "id", "options": {}}
+                                ]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
@@ -2281,31 +2281,31 @@ public class ImportSpecificationDeserializerExtraValidationTest {
     public void fails_if_node_target_vector_index_property_refers_to_non_existent_property() {
         assertThatThrownBy(() -> deserialize(new StringReader(
                         """
-                {
-                  "version": "1",
-                  "sources": [{
-                    "name": "a-source",
-                    "type": "jdbc",
-                    "data_source": "a-data-source",
-                    "sql": "SELECT id, name FROM my.table"
-                  }],
-                  "targets": {
-                    "nodes": [{
-                      "name": "a-node-target",
-                      "source": "a-source",
-                      "labels": ["Label"],
-                      "properties": [
-                        {"source_field": "id", "target_property": "id"}
-                      ],
-                      "schema": {
-                        "vector_indexes": [
-                            {"name": "a text index", "label": "Label", "property": "invalid", "options": {}}
-                        ]
-                      }
-                    }]
-                  }
-                }
-                """
+                        {
+                          "version": "1",
+                          "sources": [{
+                            "name": "a-source",
+                            "type": "jdbc",
+                            "data_source": "a-data-source",
+                            "sql": "SELECT id, name FROM my.table"
+                          }],
+                          "targets": {
+                            "nodes": [{
+                              "name": "a-node-target",
+                              "source": "a-source",
+                              "labels": ["Label"],
+                              "properties": [
+                                {"source_field": "id", "target_property": "id"}
+                              ],
+                              "schema": {
+                                "vector_indexes": [
+                                    {"name": "a vector index", "label": "Label", "property": "invalid", "options": {}}
+                                ]
+                              }
+                            }]
+                          }
+                        }
+                        """
                                 .stripIndent())))
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerExtraValidationTest.java
@@ -2239,4 +2239,78 @@ public class ImportSpecificationDeserializerExtraValidationTest {
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.fulltext_indexes[0].properties[0] \"invalid\" is not part of the property mappings");
     }
+
+    @Test
+    public void fails_if_node_target_vector_index_refers_to_non_existent_label() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "schema": {
+                        "vector_indexes": [
+                            {"name": "a text index", "label": "Invalid", "property": "id", "options": {}}
+                        ]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].label \"Invalid\" is not part of the defined labels");
+    }
+
+    @Test
+    public void fails_if_node_target_vector_index_property_refers_to_non_existent_property() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                {
+                  "version": "1",
+                  "sources": [{
+                    "name": "a-source",
+                    "type": "jdbc",
+                    "data_source": "a-data-source",
+                    "sql": "SELECT id, name FROM my.table"
+                  }],
+                  "targets": {
+                    "nodes": [{
+                      "name": "a-node-target",
+                      "source": "a-source",
+                      "labels": ["Label"],
+                      "properties": [
+                        {"source_field": "id", "target_property": "id"}
+                      ],
+                      "schema": {
+                        "vector_indexes": [
+                            {"name": "a text index", "label": "Label", "property": "invalid", "options": {}}
+                        ]
+                      }
+                    }]
+                  }
+                }
+                """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].property \"invalid\" is not part of the property mappings");
+    }
 }

--- a/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerNodeTargetTest.java
@@ -6615,4 +6615,621 @@ public class ImportSpecificationDeserializerNodeTargetTest {
                         "0 warning(s)",
                         "$.targets.nodes[0].schema.fulltext_indexes[0].options: integer found, object expected");
     }
+
+    @Test
+    public void fails_if_node_schema_vector_indexes_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": 42
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes: integer found, array expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_indexes_element_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [42]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0]: integer found, object expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_name_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"label": "Label", "property": "property", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0]: required property 'name' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_name_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": 42, "label": "Label", "property": "property", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].name: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_name_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "", "label": "Label", "property": "property", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].name: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_name_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "   ", "label": "Label", "property": "property", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].name: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_label_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "property": "property", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0]: required property 'label' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_label_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": 42, "property": "property", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].label: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_label_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": "", "property": "property", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].label: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_label_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": "   ", "property": "property", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].label: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_property_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": "Label", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0]: required property 'property' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_property_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": "Label", "property": 42, "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].property: integer found, string expected");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_property_is_empty() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": "Label", "property": "", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].property: must be at least 1 characters long");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_property_is_blank() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": "Label", "property": "   ", "options": {}}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].property: does not match the regex pattern \\S+");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_options_is_missing() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": "Label", "property": "property"}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0]: required property 'options' not found");
+    }
+
+    @Test
+    public void fails_if_node_schema_vector_index_options_is_wrongly_typed() {
+        assertThatThrownBy(() -> deserialize(new StringReader(
+                        """
+                        {
+                            "version": "1",
+                            "sources": [{
+                                "name": "a-source",
+                                "type": "jdbc",
+                                "data_source": "a-data-source",
+                                "sql": "SELECT id, name FROM my.table"
+                            }],
+                            "targets": {
+                                "nodes": [{
+                                    "active": true,
+                                    "name": "a-target",
+                                    "source": "a-source",
+                                    "write_mode": "merge",
+                                    "labels": ["Label"],
+                                    "properties": [
+                                        {"source_field": "field", "target_property": "property"}
+                                    ],
+                                    "schema": {
+                                        "vector_indexes": [
+                                            {"name": "a vector index", "label": "Label", "property": "property", "options": 42}
+                                        ]
+                                    }
+                                }]
+                            }
+                        }
+                        """
+                                .stripIndent())))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.vector_indexes[0].options: integer found, object expected");
+    }
 }


### PR DESCRIPTION
This adds coverage for the vector indexes of the node schema section of the spec.
