### PR TITLE
fix: property helpers

### DIFF
--- a/src/main/java/org/neo4j/importer/v1/targets/EntityTarget.java
+++ b/src/main/java/org/neo4j/importer/v1/targets/EntityTarget.java
@@ -49,6 +49,10 @@ public abstract class EntityTarget extends Target {
         return sourceTransformations;
     }
 
+    public List<String> getAllProperties() {
+        return getProperties().stream().map(PropertyMapping::getTargetProperty).collect(Collectors.toList());
+    }
+
     public List<PropertyMapping> getProperties() {
         // properties can be null for relationship targets
         return properties != null ? properties : Collections.emptyList();
@@ -62,10 +66,6 @@ public abstract class EntityTarget extends Target {
      * part of key constraints.
      */
     public abstract List<String> getKeyProperties();
-
-    public List<String> getAllProperties() {
-        return properties.stream().map(PropertyMapping::getTargetProperty).collect(Collectors.toList());
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/org/neo4j/importer/v1/targets/NodeTarget.java
+++ b/src/main/java/org/neo4j/importer/v1/targets/NodeTarget.java
@@ -57,6 +57,9 @@ public class NodeTarget extends EntityTarget {
 
     @Override
     public List<String> getKeyProperties() {
+        if (schema == null) {
+            return new ArrayList<>(0);
+        }
         Set<String> result = schema.getKeyConstraints().stream()
                 .flatMap(NodeTarget::propertyStream)
                 .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/src/main/java/org/neo4j/importer/v1/targets/RelationshipTarget.java
+++ b/src/main/java/org/neo4j/importer/v1/targets/RelationshipTarget.java
@@ -98,6 +98,9 @@ public class RelationshipTarget extends EntityTarget {
 
     @Override
     public List<String> getKeyProperties() {
+        if (schema == null) {
+            return new ArrayList<>(0);
+        }
         Set<String> result = schema.getKeyConstraints().stream()
                 .flatMap(RelationshipTarget::propertyStream)
                 .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/src/test/java/org/neo4j/importer/v1/targets/EntityTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/targets/EntityTargetTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.targets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EntityTargetTest {
+
+    @Test
+    void returns_no_node_properties_when_they_are_not_defined() {
+        List<PropertyMapping> properties = null;
+        var target = new NodeTarget(
+                true, "a-target", "a-source", null, WriteMode.CREATE, null, List.of("Label"), properties, null);
+
+        assertThat(target.getAllProperties()).isEmpty();
+    }
+
+    @Test
+    void returns_no_relationship_properties_when_they_are_not_defined() {
+        List<PropertyMapping> properties = null;
+        var target = new RelationshipTarget(
+                true,
+                "a-target",
+                "a-source",
+                null,
+                "TYPE",
+                WriteMode.CREATE,
+                NodeMatchMode.MERGE,
+                null,
+                "a-node-target",
+                "a-node-target",
+                properties,
+                null);
+
+        assertThat(target.getAllProperties()).isEmpty();
+    }
+}

--- a/src/test/java/org/neo4j/importer/v1/targets/NodeTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/targets/NodeTargetTest.java
@@ -26,6 +26,23 @@ class NodeTargetTest {
     private final Random random = new Random();
 
     @Test
+    void returns_no_keys_when_schema_is_not_defined() {
+        NodeSchema schema = null;
+        var target = new NodeTarget(
+                true,
+                "a-target",
+                "a-source",
+                null,
+                WriteMode.CREATE,
+                null,
+                List.of("Label"),
+                List.of(mappingTo("prop")),
+                schema);
+
+        assertThat(target.getKeyProperties()).isEmpty();
+    }
+
+    @Test
     void returns_key_properties() {
         var properties = List.of(mappingTo("prop1"), mappingTo("prop2"), mappingTo("prop3"), mappingTo("prop4"));
         var schema =

--- a/src/test/java/org/neo4j/importer/v1/targets/RelationshipTargetTest.java
+++ b/src/test/java/org/neo4j/importer/v1/targets/RelationshipTargetTest.java
@@ -27,6 +27,26 @@ class RelationshipTargetTest {
     private final Random random = new Random();
 
     @Test
+    void returns_no_keys_when_schema_is_not_defined() {
+        RelationshipSchema schema = null;
+        var target = new RelationshipTarget(
+                true,
+                "a-target",
+                "a-source",
+                null,
+                "TYPE",
+                WriteMode.CREATE,
+                NodeMatchMode.MERGE,
+                null,
+                "a-node-target",
+                "a-node-target",
+                List.of(mappingTo("prop")),
+                schema);
+
+        assertThat(target.getKeyProperties()).isEmpty();
+    }
+
+    @Test
     void returns_key_properties() {
         var properties = List.of(mappingTo("prop1"), mappingTo("prop2"), mappingTo("prop3"), mappingTo("prop4"));
         var schema = schemaFor(List.of(key(List.of("prop1", "prop2")), key(List.of("prop2", "prop4"))));


### PR DESCRIPTION
Fixes 2 issues wrt properties.

1. `getKeyProperties` now accounts for `null` `schema`
2. `getAllProperties` now accounts for `null` `properties`