### PR TITLE
feat: expose entity extensions on the pipeline API

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,6 +20,10 @@
             <version>1.5.9</version>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-extensions-sql</artifactId>
             <scope>test</scope>

--- a/core/src/main/java/org/neo4j/importer/v1/pipeline/EntityTargetStep.java
+++ b/core/src/main/java/org/neo4j/importer/v1/pipeline/EntityTargetStep.java
@@ -19,6 +19,7 @@ package org.neo4j.importer.v1.pipeline;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -37,6 +38,13 @@ public abstract class EntityTargetStep extends TargetStep {
         return target().getProperties().stream()
                 .filter(mapping -> mapping.getTargetPropertyType() != null)
                 .collect(Collectors.toMap(PropertyMapping::getTargetProperty, PropertyMapping::getTargetPropertyType));
+    }
+
+    public <T extends EntityTargetExtension> Optional<T> getExtension(Class<T> type) {
+        return extensions().stream()
+                .filter(ext -> type.isAssignableFrom(ext.getClass()))
+                .map(type::cast)
+                .findFirst();
     }
 
     public List<EntityTargetExtension> extensions() {

--- a/core/src/main/java/org/neo4j/importer/v1/pipeline/EntityTargetStep.java
+++ b/core/src/main/java/org/neo4j/importer/v1/pipeline/EntityTargetStep.java
@@ -40,7 +40,7 @@ public abstract class EntityTargetStep extends TargetStep {
                 .collect(Collectors.toMap(PropertyMapping::getTargetProperty, PropertyMapping::getTargetPropertyType));
     }
 
-    public <T extends EntityTargetExtension> Optional<T> getExtension(Class<T> type) {
+    public <T extends EntityTargetExtension> Optional<T> extension(Class<T> type) {
         return extensions().stream()
                 .filter(ext -> type.isAssignableFrom(ext.getClass()))
                 .map(type::cast)

--- a/core/src/main/java17/org/neo4j/importer/v1/pipeline/EntityTargetStep.java
+++ b/core/src/main/java17/org/neo4j/importer/v1/pipeline/EntityTargetStep.java
@@ -40,7 +40,7 @@ public abstract sealed class EntityTargetStep extends TargetStep permits NodeTar
                 .collect(Collectors.toMap(PropertyMapping::getTargetProperty, PropertyMapping::getTargetPropertyType));
     }
 
-    public <T extends EntityTargetExtension> Optional<T> getExtension(Class<T> type) {
+    public <T extends EntityTargetExtension> Optional<T> extension(Class<T> type) {
         return extensions().stream()
                 .filter(ext -> type.isAssignableFrom(ext.getClass()))
                 .map(type::cast)

--- a/core/src/main/java17/org/neo4j/importer/v1/pipeline/EntityTargetStep.java
+++ b/core/src/main/java17/org/neo4j/importer/v1/pipeline/EntityTargetStep.java
@@ -19,6 +19,7 @@ package org.neo4j.importer.v1.pipeline;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -39,7 +40,14 @@ public abstract sealed class EntityTargetStep extends TargetStep permits NodeTar
                 .collect(Collectors.toMap(PropertyMapping::getTargetProperty, PropertyMapping::getTargetPropertyType));
     }
 
-    public List<EntityTargetExtension> getExtensions() {
+    public <T extends EntityTargetExtension> Optional<T> getExtension(Class<T> type) {
+        return extensions().stream()
+                .filter(ext -> type.isAssignableFrom(ext.getClass()))
+                .map(type::cast)
+                .findFirst();
+    }
+
+    public List<EntityTargetExtension> extensions() {
         return target().getExtensions();
     }
 

--- a/core/src/test/java/org/neo4j/importer/v1/pipeline/EntityTargetStepTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/pipeline/EntityTargetStepTest.java
@@ -34,7 +34,7 @@ class EntityTargetStepTest {
         var extension = new ExtensionOne();
         var step = stepWithExtensions(extension);
 
-        var result = step.getExtension(ExtensionOne.class);
+        var result = step.extension(ExtensionOne.class);
 
         assertThat(result)
                 .overridingErrorMessage("expected to find matching extension")
@@ -46,7 +46,7 @@ class EntityTargetStepTest {
     void finds_no_extensions() {
         var step = stepWithoutExtensions();
 
-        assertThat(step.getExtension(ExtensionOne.class))
+        assertThat(step.extension(ExtensionOne.class))
                 .overridingErrorMessage("expected not to find any extension")
                 .isEmpty();
     }
@@ -55,7 +55,7 @@ class EntityTargetStepTest {
     void finds_no_matching_extensions() {
         var step = stepWithExtensions(new ExtensionTwo());
 
-        assertThat(step.getExtension(ExtensionOne.class))
+        assertThat(step.extension(ExtensionOne.class))
                 .overridingErrorMessage("expected not to find any matching extension")
                 .isEmpty();
     }
@@ -72,7 +72,7 @@ class EntityTargetStepTest {
     private static EntityTargetStep step(List<EntityTargetExtension> extensions) {
         var entityStep = mock(EntityTargetStep.class);
         when(entityStep.extensions()).thenReturn(extensions);
-        when(entityStep.getExtension(any())).thenCallRealMethod();
+        when(entityStep.extension(any())).thenCallRealMethod();
         return entityStep;
     }
 

--- a/core/src/test/java/org/neo4j/importer/v1/pipeline/EntityTargetStepTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/pipeline/EntityTargetStepTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.neo4j.importer.v1.targets.EntityTargetExtension;
+
+class EntityTargetStepTest {
+
+    @Test
+    void finds_matching_extensions() {
+        var extension = new ExtensionOne();
+        var step = stepWithExtensions(extension);
+
+        var result = step.getExtension(ExtensionOne.class);
+
+        assertThat(result)
+                .overridingErrorMessage("expected to find matching extension")
+                .isPresent()
+                .contains(extension);
+    }
+
+    @Test
+    void finds_no_extensions() {
+        var step = stepWithoutExtensions();
+
+        assertThat(step.getExtension(ExtensionOne.class))
+                .overridingErrorMessage("expected not to find any extension")
+                .isEmpty();
+    }
+
+    @Test
+    void finds_no_matching_extensions() {
+        var step = stepWithExtensions(new ExtensionTwo());
+
+        assertThat(step.getExtension(ExtensionOne.class))
+                .overridingErrorMessage("expected not to find any matching extension")
+                .isEmpty();
+    }
+
+    private static EntityTargetStep stepWithoutExtensions() {
+        return step(List.of());
+    }
+
+    private static EntityTargetStep stepWithExtensions(
+            EntityTargetExtension extension, EntityTargetExtension... extensions) {
+        return step(prepend(extension, extensions));
+    }
+
+    private static EntityTargetStep step(List<EntityTargetExtension> extensions) {
+        var entityStep = mock(EntityTargetStep.class);
+        when(entityStep.extensions()).thenReturn(extensions);
+        when(entityStep.getExtension(any())).thenCallRealMethod();
+        return entityStep;
+    }
+
+    private static List<EntityTargetExtension> prepend(
+            EntityTargetExtension extension, EntityTargetExtension... extensions) {
+        var result = new ArrayList<EntityTargetExtension>();
+        result.add(extension);
+        result.addAll(Arrays.asList(extensions));
+        return List.copyOf(result);
+    }
+
+    static class ExtensionOne implements EntityTargetExtension {}
+
+    static class ExtensionTwo implements EntityTargetExtension {}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>5.23.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
                 <version>2.0.5</version>


### PR DESCRIPTION
This also fixes a mismatch between the JDK 17+ and JDK <17 extensions API.