### PR TITLE
fix: bump qs to 6.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1890,9 +1890,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   },
   "scripts": {
     "prepare": "husky"
+  },
+  "overrides": {
+    "qs": "6.15.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "prepare": "husky"
   },
   "overrides": {
-    "qs": "6.15.2"
+    "danger": {
+      "qs": "6.15.2"
+    }
   }
 }


### PR DESCRIPTION
Bumps transitive `qs` dependency to 6.15.2 via npm `overrides` to resolve the Semgrep supply chain finding.

Dependency path: `danger` → `@gitbeaker/rest` → `@gitbeaker/requester-utils` → `qs`

There is no new danger-js release that includes a `qs` update (latest is 13.0.5), so a manual `overrides` entry is required to force the safe version.

Closes CONN-1009