### PR TITLE
feat: disallow type constraints for byte array properties

### DIFF
--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoByteArrayPropertyInTypeConstraintValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoByteArrayPropertyInTypeConstraintValidator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.PropertyMapping;
+import org.neo4j.importer.v1.targets.PropertyType;
+import org.neo4j.importer.v1.targets.RelationshipTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NoByteArrayPropertyInTypeConstraintValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "NBYT-001";
+
+    private final List<String> invalidPaths = new ArrayList<>();
+
+    @Override
+    public Set<Class<? extends SpecificationValidator>> requires() {
+        return Set.of(NoDuplicatedTargetPropertyValidator.class, NoDanglingPropertyInTypeConstraintValidator.class);
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var byteArrayProps = byteArrayProperties(target);
+        if (byteArrayProps.isEmpty()) {
+            return;
+        }
+        var typeConstraints = target.getSchema().getTypeConstraints();
+        for (int i = 0; i < typeConstraints.size(); i++) {
+            var typeConstraint = typeConstraints.get(i);
+            if (!byteArrayProps.contains(typeConstraint.getProperty())) {
+                continue;
+            }
+            invalidPaths.add(String.format("$.targets.nodes[%d].schema.type_constraints[%d].property", index, i));
+        }
+    }
+
+    @Override
+    public void visitRelationshipTarget(int index, RelationshipTarget target) {
+        var byteArrayProps = byteArrayProperties(target);
+        if (byteArrayProps.isEmpty()) {
+            return;
+        }
+        var typeConstraints = target.getSchema().getTypeConstraints();
+        for (int i = 0; i < typeConstraints.size(); i++) {
+            var typeConstraint = typeConstraints.get(i);
+            if (!byteArrayProps.contains(typeConstraint.getProperty())) {
+                continue;
+            }
+            invalidPaths.add(
+                    String.format("$.targets.relationships[%d].schema.type_constraints[%d].property", index, i));
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach(
+                path -> builder.addError(path, ERROR_CODE, "BYTE_ARRAY is not supported in type constraints"));
+        return !invalidPaths.isEmpty();
+    }
+
+    private static Set<String> byteArrayProperties(EntityTarget target) {
+        return target.getProperties().stream()
+                .filter(mapping -> PropertyType.BYTE_ARRAY.equals(mapping.getTargetPropertyType()))
+                .map(PropertyMapping::getTargetProperty)
+                .collect(Collectors.toSet());
+    }
+}

--- a/core/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/core/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -1,6 +1,7 @@
 # keep this alphabetically sorted
 org.neo4j.importer.v1.validation.plugin.AtLeastOneActiveTargetValidator
 org.neo4j.importer.v1.validation.plugin.NoBlankCypherActionQueryValidator
+org.neo4j.importer.v1.validation.plugin.NoByteArrayPropertyInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingActiveNodeReferenceValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingDependsOnValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingKeyInNodeReferenceKeyMappingsValidator

--- a/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -8290,6 +8290,74 @@ class ImportSpecificationDeserializerTest {
                         "[$.targets.relationships[0].type] Graph type cannot be generated: the type A_REPEATED_TYPE is defined more than once (offending occurrences in $.targets.relationships[1].type");
     }
 
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_node_target_type_constraint_refers_to_byte_array_property(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[NBYT-001][$.targets.nodes[0].schema.type_constraints[0].property] BYTE_ARRAY is not supported in type constraints");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_relationship_target_type_constraint_refers_to_byte_array_property(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[NBYT-001][$.targets.relationships[0].schema.type_constraints[0].property] BYTE_ARRAY is not supported in type constraints");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void ignores_byte_array_property_in_type_constraints_when_duplicated_property_is_defined(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[DUPL-009][$.targets.nodes[0].properties[0].target_property] $.targets.nodes[0].properties[0].target_property \"dup\" must be defined only once but found 2 occurrences")
+                .hasMessageNotContaining("NBYT-001");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void ignores_byte_array_property_in_type_constraints_when_dangling_property_is_defined(
+            SpecFormat format, TestInfo testInfo) {
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[DANG-005][$.targets.nodes[0].schema.type_constraints[1].property] $.targets.nodes[0].schema.type_constraints[1].property \"non_existent\" is not part of the property mappings")
+                .hasMessageNotContaining("NBYT-001");
+    }
+
     private static FileReader specReader(SpecFormat format, TestInfo testInfo) {
         var spec = String.format(
                 "/specs/import_specification_deserializer_test/%s.%s",

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_target_type_constraint_refers_to_byte_array_property.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_target_type_constraint_refers_to_byte_array_property.json
@@ -1,0 +1,32 @@
+{
+  "version": "1",
+  "sources": [{
+    "name": "a-source",
+    "type": "jdbc",
+    "data_source": "a-data-source",
+    "sql": "SELECT id FROM my.table"
+  }],
+  "targets": {
+    "nodes": [{
+      "name": "a-node-target",
+      "source": "a-source",
+      "labels": ["Label"],
+      "properties": [
+        {
+          "source_field": "id",
+          "target_property": "property_with_byte_array",
+          "target_property_type": "BYTE_ARRAY"
+        }
+      ],
+      "schema": {
+        "type_constraints": [
+          {
+            "name": "a type constraint",
+            "label": "Label",
+            "property": "property_with_byte_array"
+          }
+        ]
+      }
+    }]
+  }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_target_type_constraint_refers_to_byte_array_property.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_target_type_constraint_refers_to_byte_array_property.yaml
@@ -1,0 +1,22 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property_with_byte_array
+      target_property_type: BYTE_ARRAY
+    schema:
+      type_constraints:
+      - name: a type constraint
+        label: Label
+        property: property_with_byte_array

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_target_type_constraint_refers_to_byte_array_property.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_target_type_constraint_refers_to_byte_array_property.json
@@ -1,0 +1,48 @@
+{
+  "version": "1",
+  "sources": [{
+    "name": "a-source",
+    "type": "jdbc",
+    "data_source": "a-data-source",
+    "sql": "SELECT id, name FROM my.table"
+  }],
+  "targets": {
+    "nodes": [{
+      "name": "a-node-target",
+      "source": "a-source",
+      "labels": ["Label"],
+      "properties": [
+        {"source_field": "id", "target_property": "id"}
+      ],
+      "schema": {
+        "key_constraints": [{
+          "name": "node-key-constraint",
+          "label": "Label",
+          "properties": ["id"]
+        }]
+      }
+    }],
+    "relationships": [{
+      "name": "a-relationship-target",
+      "source": "a-source",
+      "type": "TYPE",
+      "start_node_reference": "a-node-target",
+      "end_node_reference": "a-node-target",
+      "properties": [
+        {
+          "source_field": "id",
+          "target_property": "property_with_byte_array",
+          "target_property_type": "BYTE_ARRAY"
+        }
+      ],
+      "schema": {
+        "type_constraints": [
+          {
+            "name": "a type constraint",
+            "property": "property_with_byte_array"
+          }
+        ]
+      }
+    }]
+  }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_target_type_constraint_refers_to_byte_array_property.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_target_type_constraint_refers_to_byte_array_property.yaml
@@ -1,0 +1,36 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: node-key-constraint
+        label: Label
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target
+    properties:
+    - source_field: id
+      target_property: property_with_byte_array
+      target_property_type: BYTE_ARRAY
+    schema:
+      type_constraints:
+      - name: a type constraint
+        property: property_with_byte_array

--- a/core/src/test/resources/specs/import_specification_deserializer_test/ignores_byte_array_property_in_type_constraints_when_dangling_property_is_defined.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/ignores_byte_array_property_in_type_constraints_when_dangling_property_is_defined.json
@@ -1,0 +1,37 @@
+{
+  "version": "1",
+  "sources": [{
+    "name": "a-source",
+    "type": "jdbc",
+    "data_source": "a-data-source",
+    "sql": "SELECT id, name FROM my.table"
+  }],
+  "targets": {
+    "nodes": [{
+      "name": "a-node-target",
+      "source": "a-source",
+      "labels": ["Label"],
+      "properties": [
+        {
+          "source_field": "id",
+          "target_property": "property_with_byte_array",
+          "target_property_type": "BYTE_ARRAY"
+        }
+      ],
+      "schema": {
+        "type_constraints": [
+          {
+            "name": "a type constraint",
+            "label": "Label",
+            "property": "property_with_byte_array"
+          },
+          {
+            "name": "another type constraint",
+            "label": "Label",
+            "property": "non_existent"
+          }
+        ]
+      }
+    }]
+  }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/ignores_byte_array_property_in_type_constraints_when_dangling_property_is_defined.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/ignores_byte_array_property_in_type_constraints_when_dangling_property_is_defined.yaml
@@ -1,0 +1,25 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property_with_byte_array
+      target_property_type: BYTE_ARRAY
+    schema:
+      type_constraints:
+      - name: a type constraint
+        label: Label
+        property: property_with_byte_array
+      - name: another type constraint
+        label: Label
+        property: non_existent

--- a/core/src/test/resources/specs/import_specification_deserializer_test/ignores_byte_array_property_in_type_constraints_when_duplicated_property_is_defined.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/ignores_byte_array_property_in_type_constraints_when_duplicated_property_is_defined.json
@@ -1,0 +1,37 @@
+{
+  "version": "1",
+  "sources": [{
+    "name": "a-source",
+    "type": "jdbc",
+    "data_source": "a-data-source",
+    "sql": "SELECT id, name FROM my.table"
+  }],
+  "targets": {
+    "nodes": [{
+      "name": "a-node-target",
+      "source": "a-source",
+      "labels": ["Label"],
+      "properties": [
+        {
+          "source_field": "id",
+          "target_property": "dup",
+          "target_property_type": "BYTE_ARRAY"
+        },
+        {
+          "source_field": "name",
+          "target_property": "dup",
+          "target_property_type": "STRING"
+        }
+      ],
+      "schema": {
+        "type_constraints": [
+          {
+            "name": "a type constraint",
+            "label": "Label",
+            "property": "dup"
+          }
+        ]
+      }
+    }]
+  }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/ignores_byte_array_property_in_type_constraints_when_duplicated_property_is_defined.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/ignores_byte_array_property_in_type_constraints_when_duplicated_property_is_defined.yaml
@@ -1,0 +1,25 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: dup
+      target_property_type: BYTE_ARRAY
+    - source_field: name
+      target_property: dup
+      target_property_type: STRING
+    schema:
+      type_constraints:
+      - name: a type constraint
+        label: Label
+        property: dup


### PR DESCRIPTION
Cypher supports byte array values as pass-through, but does not support byte arrays as "first class citizen".
As a consequence, type constraints do not support byte arrays.