### PR TITLE
fix: compute key and existence redundancies properly

### DIFF
--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndExistenceConstraintsValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndExistenceConstraintsValidator.java
@@ -52,27 +52,28 @@ public class NoRedundantKeyAndExistenceConstraintsValidator implements Specifica
     @Override
     public void visitNodeTarget(int index, NodeTarget target) {
         var schema = target.getSchema();
-        var paths = new LinkedHashMap<SchemaNodePattern, List<String>>();
+        var existencePaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
         var existenceBasePath = String.format("$.targets.nodes[%d].schema.existence_constraints", index);
         var existenceConstraints = schema.getExistenceConstraints();
         for (int i = 0; i < existenceConstraints.size(); i++) {
             var constraint = existenceConstraints.get(i);
             var labelAndProp = new SchemaNodePattern(constraint.getLabel(), constraint.getProperty());
-            paths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
+            existencePaths
+                    .computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", existenceBasePath, i));
         }
+        var keyPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
         var keyBasePath = String.format("$.targets.nodes[%d].schema.key_constraints", index);
         var keyConstraints = schema.getKeyConstraints();
         for (int i = 0; i < keyConstraints.size(); i++) {
             var constraint = keyConstraints.get(i);
             for (String property : constraint.getProperties()) {
                 var labelAndProp = new SchemaNodePattern(constraint.getLabel(), property);
-                paths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
+                keyPaths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
                         .add(String.format("%s[%d]", keyBasePath, i));
             }
         }
-        List<List<String>> redundancies =
-                paths.values().stream().filter(allPaths -> allPaths.size() > 1).collect(Collectors.toList());
+        var redundancies = redundancies(existencePaths, keyPaths);
 
         if (!redundancies.isEmpty()) {
             var schemaPath = String.format("$.targets.nodes[%d].schema", index);
@@ -86,30 +87,48 @@ public class NoRedundantKeyAndExistenceConstraintsValidator implements Specifica
         if (schema.isEmpty()) {
             return;
         }
-        var paths = new LinkedHashMap<String, List<String>>();
+        var existencePaths = new LinkedHashMap<String, List<String>>();
         var existenceBasePath = String.format("$.targets.relationships[%d].schema.existence_constraints", index);
         var existenceConstraints = schema.getExistenceConstraints();
         for (int i = 0; i < existenceConstraints.size(); i++) {
             var constraint = existenceConstraints.get(i);
-            paths.computeIfAbsent(constraint.getProperty(), (key) -> new ArrayList<>(1))
+            existencePaths
+                    .computeIfAbsent(constraint.getProperty(), (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", existenceBasePath, i));
         }
+        var keyPaths = new LinkedHashMap<String, List<String>>();
         var keyBasePath = String.format("$.targets.relationships[%d].schema.key_constraints", index);
         var keyConstraints = schema.getKeyConstraints();
         for (int i = 0; i < keyConstraints.size(); i++) {
             var constraint = keyConstraints.get(i);
             for (String property : constraint.getProperties()) {
-                paths.computeIfAbsent(property, (key) -> new ArrayList<>(1))
+                keyPaths.computeIfAbsent(property, (key) -> new ArrayList<>(1))
                         .add(String.format("%s[%d]", keyBasePath, i));
             }
         }
-        List<List<String>> redundancies =
-                paths.values().stream().filter(strings -> strings.size() > 1).collect(Collectors.toList());
+        var redundancies = redundancies(existencePaths, keyPaths);
 
         if (!redundancies.isEmpty()) {
             var schemaPath = String.format("$.targets.relationships[%d].schema", index);
             invalidPaths.put(schemaPath, redundancies);
         }
+    }
+
+    // a redundancy exists only when the same label/property (or property, for relationships) is covered by both an
+    // existence constraint and a key constraint. Two key constraints sharing a property are not redundant.
+    private static <K> List<List<String>> redundancies(
+            Map<K, List<String>> existencePaths, Map<K, List<String>> keyPaths) {
+        var redundancies = new ArrayList<List<String>>();
+        existencePaths.forEach((pattern, existenceDefinitions) -> {
+            var keyDefinitions = keyPaths.get(pattern);
+            if (keyDefinitions != null) {
+                var redundantDefinitions = new ArrayList<String>(existenceDefinitions.size() + keyDefinitions.size());
+                redundantDefinitions.addAll(existenceDefinitions);
+                redundantDefinitions.addAll(keyDefinitions);
+                redundancies.add(redundantDefinitions);
+            }
+        });
+        return redundancies;
     }
 
     @Override

--- a/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -4786,6 +4786,30 @@ class ImportSpecificationDeserializerTest {
 
     @ParameterizedTest
     @EnumSource(SpecFormat.class)
+    void does_not_fail_if_node_key_constraints_share_label_and_property(SpecFormat format, TestInfo testInfo) {
+
+        assertThatCode(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void does_not_fail_if_relationship_key_constraints_share_property(SpecFormat format, TestInfo testInfo) {
+
+        assertThatCode(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
     void does_not_report_redundancy_if_key_and_existence_constraint_define_invalid_labels(
             SpecFormat format, TestInfo testInfo) {
 

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_key_constraints_share_label_and_property.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_key_constraints_share_label_and_property.json
@@ -1,0 +1,29 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "active": true,
+          "name": "a-target",
+          "source": "a-source",
+          "write_mode": "merge",
+          "labels": ["Label"],
+          "properties": [
+            {"source_field": "id", "target_property": "property1"},
+            {"source_field": "name", "target_property": "property2"}
+          ],
+          "schema": {
+              "key_constraints": [
+                 {"name": "a key constraint", "label": "Label", "properties": ["property1"]},
+                 {"name": "a composite key constraint", "label": "Label", "properties": ["property1", "property2"]}
+              ]
+          }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_key_constraints_share_label_and_property.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_key_constraints_share_label_and_property.yaml
@@ -1,0 +1,31 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    schema:
+      key_constraints:
+      - name: a key constraint
+        label: Label
+        properties:
+        - property1
+      - name: a composite key constraint
+        label: Label
+        properties:
+        - property1
+        - property2

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_key_constraints_share_property.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_key_constraints_share_property.json
@@ -1,0 +1,44 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "name": "a-node-target",
+          "source": "a-source",
+          "labels": ["Label"],
+          "properties": [
+            {"source_field": "id", "target_property": "id"}
+          ],
+          "schema": {
+              "key_constraints": [{
+                 "name": "a-key-constraint",
+                 "label": "Label",
+                 "properties": ["id"]
+              }]
+          }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a key constraint", "properties": ["property1"]},
+                    {"name": "a composite key constraint", "properties": ["property1", "property2"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_key_constraints_share_property.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_key_constraints_share_property.yaml
@@ -1,0 +1,42 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: a-key-constraint
+        label: Label
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    schema:
+      key_constraints:
+      - name: a key constraint
+        properties:
+        - property1
+      - name: a composite key constraint
+        properties:
+        - property1
+        - property2


### PR DESCRIPTION
This pull request refines the logic for detecting redundant constraints in the `NoRedundantKeyAndExistenceConstraintsValidator` and adds new tests to ensure correct behavior. The main improvement is that redundancies are now only reported when the same label/property (for nodes) or property (for relationships) is covered by both an existence constraint and a key constraint, not when multiple key constraints share the same property.