### PR TITLE
fix: pick correct constraints when there are many

### DIFF
--- a/core/src/main/java/org/neo4j/importer/v1/pipeline/ImportPipeline.java
+++ b/core/src/main/java/org/neo4j/importer/v1/pipeline/ImportPipeline.java
@@ -41,7 +41,10 @@ import org.neo4j.importer.v1.graph.Graphs;
 import org.neo4j.importer.v1.sources.Source;
 import org.neo4j.importer.v1.targets.CustomQueryTarget;
 import org.neo4j.importer.v1.targets.KeyMapping;
+import org.neo4j.importer.v1.targets.NodeKeyConstraint;
+import org.neo4j.importer.v1.targets.NodeSchema;
 import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.NodeUniqueConstraint;
 import org.neo4j.importer.v1.targets.PropertyMapping;
 import org.neo4j.importer.v1.targets.RelationshipTarget;
 import org.neo4j.importer.v1.targets.Target;
@@ -357,8 +360,35 @@ public class ImportPipeline implements Iterable<ImportStep>, Serializable {
                         target.getExtensions(),
                         target.getLabels(),
                         mappings,
-                        target.getSchema()),
+                        restrictSchemaToReferencedKey(target.getSchema(), keyMappings)),
                 nodeTarget.dependencies());
+    }
+
+    // a node target may define several key (or unique) constraints. When a relationship references such a node, its
+    // key mappings pick exactly one of them. Retain only the constraints fully covered by the referenced properties so
+    // that the node lookup matches on the referenced key alone rather than on the union of every key constraint.
+    private static NodeSchema restrictSchemaToReferencedKey(NodeSchema schema, List<KeyMapping> keyMappings) {
+        if (schema == null) {
+            return null;
+        }
+        var referencedProperties =
+                keyMappings.stream().map(KeyMapping::getNodeProperty).collect(Collectors.toSet());
+        List<NodeKeyConstraint> keyConstraints = schema.getKeyConstraints().stream()
+                .filter(constraint -> referencedProperties.containsAll(constraint.getProperties()))
+                .collect(Collectors.toList());
+        List<NodeUniqueConstraint> uniqueConstraints = schema.getUniqueConstraints().stream()
+                .filter(constraint -> referencedProperties.containsAll(constraint.getProperties()))
+                .collect(Collectors.toList());
+        return new NodeSchema(
+                schema.getTypeConstraints(),
+                keyConstraints,
+                uniqueConstraints,
+                schema.getExistenceConstraints(),
+                schema.getRangeIndexes(),
+                schema.getTextIndexes(),
+                schema.getPointIndexes(),
+                schema.getFullTextIndexes(),
+                schema.getVectorIndexes());
     }
 
     @SafeVarargs

--- a/core/src/main/java/org/neo4j/importer/v1/pipeline/ImportPipeline.java
+++ b/core/src/main/java/org/neo4j/importer/v1/pipeline/ImportPipeline.java
@@ -365,8 +365,9 @@ public class ImportPipeline implements Iterable<ImportStep>, Serializable {
     }
 
     // a node target may define several key (or unique) constraints. When a relationship references such a node, its
-    // key mappings pick exactly one of them. Retain only the constraints fully covered by the referenced properties so
-    // that the node lookup matches on the referenced key alone rather than on the union of every key constraint.
+    // key mappings pick the correct constraints by retaining only the constraints fully covered by the referenced
+    // properties so that the node lookup matches on the referenced key alone rather than on the union of every key
+    // constraint.
     private static NodeSchema restrictSchemaToReferencedKey(NodeSchema schema, List<KeyMapping> keyMappings) {
         if (schema == null) {
             return null;

--- a/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -4810,6 +4810,32 @@ class ImportSpecificationDeserializerTest {
 
     @ParameterizedTest
     @EnumSource(SpecFormat.class)
+    void does_not_fail_if_relationship_references_node_via_shorter_overlapping_key_constraint(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatCode(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void does_not_fail_if_relationship_references_node_via_longer_overlapping_key_constraint(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatCode(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
     void does_not_report_redundancy_if_key_and_existence_constraint_define_invalid_labels(
             SpecFormat format, TestInfo testInfo) {
 

--- a/core/src/test/java/org/neo4j/importer/v1/pipeline/ImportPipelineTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/pipeline/ImportPipelineTest.java
@@ -232,6 +232,74 @@ class ImportPipelineTest {
                 .containsExactlyInAnyOrder("played-relationships");
     }
 
+    @Test
+    void resolves_relationship_node_reference_to_the_matched_overlapping_key_constraint() {
+        var firstNameKey = new NodeKeyConstraint("person-first-name-key", "Person", List.of("firstName"), Map.of());
+        var fullNameKey =
+                new NodeKeyConstraint("person-full-name-key", "Person", List.of("firstName", "lastName"), Map.of());
+        // start reference matches the single-property key, end reference matches the composite key
+        var startRef = new NodeReference("person-nodes", List.of(new KeyMapping("knower_first", "firstName")));
+        var endRef = new NodeReference(
+                "person-nodes",
+                List.of(new KeyMapping("known_first", "firstName"), new KeyMapping("known_last", "lastName")));
+        var spec = new ImportSpecification(
+                "a-version",
+                new HashMap<>(),
+                List.of(new DummySource("people"), new DummySource("acquaintances")),
+                new Targets(
+                        List.of(new NodeTarget(
+                                true,
+                                "person-nodes",
+                                "people",
+                                List.of(),
+                                WriteMode.MERGE,
+                                (ObjectNode) null,
+                                List.of("Person"),
+                                List.of(
+                                        new PropertyMapping("first_name", "firstName", PropertyType.STRING),
+                                        new PropertyMapping("last_name", "lastName", PropertyType.STRING)),
+                                new NodeSchema(
+                                        null,
+                                        List.of(firstNameKey, fullNameKey),
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null))),
+                        List.of(new RelationshipTarget(
+                                true,
+                                "knows-relationships",
+                                "acquaintances",
+                                List.of(),
+                                "KNOWS",
+                                WriteMode.MERGE,
+                                NodeMatchMode.MATCH,
+                                (ObjectNode) null,
+                                startRef,
+                                endRef,
+                                List.of(),
+                                null)),
+                        List.of()),
+                List.of());
+
+        var pipeline = ImportPipeline.of(spec);
+
+        var relationships = stream(pipeline)
+                .filter(step -> step instanceof RelationshipTargetStep)
+                .map(step -> (RelationshipTargetStep) step)
+                .collect(Collectors.toList());
+        assertThat(relationships).hasSize(1);
+        var relationship = relationships.get(0);
+        assertThat(relationship.startNode().keyProperties())
+                .containsExactly(new PropertyMapping("knower_first", "firstName", PropertyType.STRING));
+        assertThat(relationship.endNode().keyProperties())
+                .containsExactly(
+                        new PropertyMapping("known_first", "firstName", PropertyType.STRING),
+                        new PropertyMapping("known_last", "lastName", PropertyType.STRING));
+    }
+
     private static @NotNull NodeSchema schemaFor(NodeKeyConstraint keyConstraint) {
         return new NodeSchema(null, List.of(keyConstraint), null, null, null, null, null, null, null);
     }

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_longer_overlapping_key_constraint.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_longer_overlapping_key_constraint.json
@@ -1,0 +1,46 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT knower_first, knower_last, known_first, known_last FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "name": "person",
+          "source": "a-source",
+          "labels": ["Person"],
+          "properties": [
+            {"source_field": "knower_first", "target_property": "firstName"},
+            {"source_field": "knower_last", "target_property": "lastName"}
+          ],
+          "schema": {
+              "key_constraints": [
+                 {"name": "person-first-name-key", "label": "Person", "properties": ["firstName"]},
+                 {"name": "person-full-name-key", "label": "Person", "properties": ["firstName", "lastName"]}
+              ]
+          }
+        }],
+        "relationships": [{
+            "name": "knows",
+            "source": "a-source",
+            "type": "KNOWS",
+            "start_node_reference": {
+                "name": "person",
+                "key_mappings": [
+                    {"source_field": "knower_first", "node_property": "firstName"},
+                    {"source_field": "knower_last", "node_property": "lastName"}
+                ]
+            },
+            "end_node_reference": {
+                "name": "person",
+                "key_mappings": [
+                    {"source_field": "known_first", "node_property": "firstName"},
+                    {"source_field": "known_last", "node_property": "lastName"}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_longer_overlapping_key_constraint.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_longer_overlapping_key_constraint.yaml
@@ -1,0 +1,47 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT knower_first, knower_last, known_first, known_last FROM my.table
+targets:
+  nodes:
+  - name: person
+    source: a-source
+    labels:
+    - Person
+    properties:
+    - source_field: knower_first
+      target_property: firstName
+    - source_field: knower_last
+      target_property: lastName
+    schema:
+      key_constraints:
+      - name: person-first-name-key
+        label: Person
+        properties:
+        - firstName
+      - name: person-full-name-key
+        label: Person
+        properties:
+        - firstName
+        - lastName
+  relationships:
+  - name: knows
+    source: a-source
+    type: KNOWS
+    start_node_reference:
+      name: person
+      key_mappings:
+      - source_field: knower_first
+        node_property: firstName
+      - source_field: knower_last
+        node_property: lastName
+    end_node_reference:
+      name: person
+      key_mappings:
+      - source_field: known_first
+        node_property: firstName
+      - source_field: known_last
+        node_property: lastName

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_shorter_overlapping_key_constraint.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_shorter_overlapping_key_constraint.json
@@ -1,0 +1,44 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT knower_first, knower_last, known_first FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "name": "person",
+          "source": "a-source",
+          "labels": ["Person"],
+          "properties": [
+            {"source_field": "knower_first", "target_property": "firstName"},
+            {"source_field": "knower_last", "target_property": "lastName"}
+          ],
+          "schema": {
+              "key_constraints": [
+                 {"name": "person-first-name-key", "label": "Person", "properties": ["firstName"]},
+                 {"name": "person-full-name-key", "label": "Person", "properties": ["firstName", "lastName"]}
+              ]
+          }
+        }],
+        "relationships": [{
+            "name": "knows",
+            "source": "a-source",
+            "type": "KNOWS",
+            "start_node_reference": {
+                "name": "person",
+                "key_mappings": [
+                    {"source_field": "knower_first", "node_property": "firstName"}
+                ]
+            },
+            "end_node_reference": {
+                "name": "person",
+                "key_mappings": [
+                    {"source_field": "known_first", "node_property": "firstName"}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_shorter_overlapping_key_constraint.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_shorter_overlapping_key_constraint.yaml
@@ -1,0 +1,43 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT knower_first, knower_last, known_first FROM my.table
+targets:
+  nodes:
+  - name: person
+    source: a-source
+    labels:
+    - Person
+    properties:
+    - source_field: knower_first
+      target_property: firstName
+    - source_field: knower_last
+      target_property: lastName
+    schema:
+      key_constraints:
+      - name: person-first-name-key
+        label: Person
+        properties:
+        - firstName
+      - name: person-full-name-key
+        label: Person
+        properties:
+        - firstName
+        - lastName
+  relationships:
+  - name: knows
+    source: a-source
+    type: KNOWS
+    start_node_reference:
+      name: person
+      key_mappings:
+      - source_field: knower_first
+        node_property: firstName
+    end_node_reference:
+      name: person
+      key_mappings:
+      - source_field: known_first
+        node_property: firstName


### PR DESCRIPTION
This pull request improves how the import pipeline resolves node references for relationships when multiple overlapping key constraints are defined on a node. Now, only the relevant key constraints that are fully covered by the referenced properties are retained, ensuring correct node matching.