### PR TITLE
feat: introduce duplicated schema definition validator

### DIFF
--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/AbstractRedundantSchemaValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/AbstractRedundantSchemaValidator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+// Shared machinery for validators that report a redundancy when the same label/property pattern is
+// covered by two different kinds of schema definition (e.g. a key constraint and a range index).
+// Subclasses extract each kind into a Map keyed by the comparison pattern (via {@link #index} or
+// {@link #indexMulti}), intersect them with {@link #redundancies}, and record the result with
+// {@link #recordRedundancies}.
+abstract class AbstractRedundantSchemaValidator implements SpecificationValidator {
+
+    private final String errorCode;
+    private final String redundancyDescription;
+    private final Map<String, List<List<String>>> invalidPaths;
+
+    protected AbstractRedundantSchemaValidator(String errorCode, String redundancyDescription) {
+        this.errorCode = errorCode;
+        this.redundancyDescription = redundancyDescription;
+        this.invalidPaths = new LinkedHashMap<>();
+    }
+
+    // Indexes each definition by the pattern returned by {@code keyOf}, mapping it to its JSON path.
+    protected static <T, K> Map<K, List<String>> index(List<T> definitions, String basePath, Function<T, K> keyOf) {
+        return indexMulti(definitions, basePath, definition -> List.of(keyOf.apply(definition)));
+    }
+
+    // Like {@link #index}, but each definition may contribute several patterns (e.g. a composite key
+    // constraint that is redundant per individual property).
+    protected static <T, K> Map<K, List<String>> indexMulti(
+            List<T> definitions, String basePath, Function<T, Collection<K>> keysOf) {
+        var paths = new LinkedHashMap<K, List<String>>();
+        for (int i = 0; i < definitions.size(); i++) {
+            var path = String.format("%s[%d]", basePath, i);
+            for (var key : keysOf.apply(definitions.get(i))) {
+                paths.computeIfAbsent(key, (ignored) -> new ArrayList<>(1)).add(path);
+            }
+        }
+        return paths;
+    }
+
+    // A redundancy exists only when the same pattern is covered by both maps. Two definitions of the
+    // same kind sharing a pattern are not reported here.
+    protected static <K> List<List<String>> redundancies(Map<K, List<String>> left, Map<K, List<String>> right) {
+        var redundancies = new ArrayList<List<String>>();
+        left.forEach((pattern, leftDefinitions) -> {
+            var rightDefinitions = right.get(pattern);
+            if (rightDefinitions != null) {
+                var redundantDefinitions = new ArrayList<String>(leftDefinitions.size() + rightDefinitions.size());
+                redundantDefinitions.addAll(leftDefinitions);
+                redundantDefinitions.addAll(rightDefinitions);
+                redundancies.add(redundantDefinitions);
+            }
+        });
+        return redundancies;
+    }
+
+    protected void recordRedundancies(String schemaPath, List<List<String>> redundancies) {
+        if (!redundancies.isEmpty()) {
+            invalidPaths.put(schemaPath, redundancies);
+        }
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidPaths.forEach((schemaPath, redundancies) -> redundancies.forEach((redundantDefinitions) -> {
+            String redundantDefs = redundantDefinitions.stream()
+                    .map(def -> def.replace(schemaPath + ".", ""))
+                    .collect(Collectors.joining(", "));
+            builder.addError(
+                    schemaPath,
+                    errorCode,
+                    String.format("%s defines redundant %s: %s", schemaPath, redundancyDescription, redundantDefs));
+        }));
+        return !invalidPaths.isEmpty();
+    }
+}

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedSchemaDefinitionValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoDuplicatedSchemaDefinitionValidator.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.*;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+// within a single target, two constraints (or two indexes) of the same kind that cover the exact same definition
+// (label(s)/properties/options, but a different name) are duplicates: they describe the same schema element declared
+// twice.
+// note: property order is significant (composite indexes are order-sensitive), so the same properties in a different
+// order are not considered duplicates. Definitions declared under the same name are left to
+// NoDuplicatedSchemaNameValidator.
+public class NoDuplicatedSchemaDefinitionValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "DUPL-012";
+
+    private final List<Definition> definitions = new ArrayList<>();
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget target) {
+        var basePath = String.format("$.targets.nodes[%d].schema", index);
+        var schema = target.getSchema();
+        collect(
+                basePath,
+                "type_constraints",
+                schema.getTypeConstraints(),
+                c -> signature(c.getLabel(), c.getProperty()));
+        collect(
+                basePath,
+                "key_constraints",
+                schema.getKeyConstraints(),
+                c -> signature(c.getLabel(), c.getProperties(), c.getOptions()));
+        collect(
+                basePath,
+                "unique_constraints",
+                schema.getUniqueConstraints(),
+                c -> signature(c.getLabel(), c.getProperties(), c.getOptions()));
+        collect(
+                basePath,
+                "existence_constraints",
+                schema.getExistenceConstraints(),
+                c -> signature(c.getLabel(), c.getProperty()));
+        collect(basePath, "range_indexes", schema.getRangeIndexes(), i -> signature(i.getLabel(), i.getProperties()));
+        collect(
+                basePath,
+                "text_indexes",
+                schema.getTextIndexes(),
+                i -> signature(i.getLabel(), i.getProperty(), i.getOptions()));
+        collect(
+                basePath,
+                "point_indexes",
+                schema.getPointIndexes(),
+                i -> signature(i.getLabel(), i.getProperty(), i.getOptions()));
+        collect(
+                basePath,
+                "fulltext_indexes",
+                schema.getFullTextIndexes(),
+                i -> signature(i.getLabels(), i.getProperties(), i.getOptions()));
+        collect(
+                basePath,
+                "vector_indexes",
+                schema.getVectorIndexes(),
+                i -> signature(i.getLabel(), i.getProperty(), i.getOptions()));
+    }
+
+    @Override
+    public void visitRelationshipTarget(int index, RelationshipTarget target) {
+        var basePath = String.format("$.targets.relationships[%d].schema", index);
+        var schema = target.getSchema();
+        collect(basePath, "type_constraints", schema.getTypeConstraints(), c -> signature(c.getProperty()));
+        collect(
+                basePath,
+                "key_constraints",
+                schema.getKeyConstraints(),
+                c -> signature(c.getProperties(), c.getOptions()));
+        collect(
+                basePath,
+                "unique_constraints",
+                schema.getUniqueConstraints(),
+                c -> signature(c.getProperties(), c.getOptions()));
+        collect(basePath, "existence_constraints", schema.getExistenceConstraints(), c -> signature(c.getProperty()));
+        collect(basePath, "range_indexes", schema.getRangeIndexes(), i -> signature(i.getProperties()));
+        collect(basePath, "text_indexes", schema.getTextIndexes(), i -> signature(i.getProperty(), i.getOptions()));
+        collect(basePath, "point_indexes", schema.getPointIndexes(), i -> signature(i.getProperty(), i.getOptions()));
+        collect(
+                basePath,
+                "fulltext_indexes",
+                schema.getFullTextIndexes(),
+                i -> signature(i.getProperties(), i.getOptions()));
+        collect(basePath, "vector_indexes", schema.getVectorIndexes(), i -> signature(i.getProperty(), i.getOptions()));
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        var groups = definitions.stream()
+                .collect(Collectors.groupingBy(
+                        definition -> List.of(definition.groupPath(), definition.signature()),
+                        LinkedHashMap::new,
+                        Collectors.toList()));
+
+        var reported = false;
+        for (var group : groups.values()) {
+            var distinctNames = group.stream().map(Definition::name).distinct().count();
+            if (distinctNames < 2) {
+                // a single name (possibly repeated) is a name clash, reported by NoDuplicatedSchemaNameValidator
+                continue;
+            }
+            reported = true;
+            var names = group.stream()
+                    .map(definition -> '"' + definition.name() + '"')
+                    .collect(Collectors.joining(", "));
+            var first = group.get(0);
+            builder.addError(
+                    first.path(),
+                    ERROR_CODE,
+                    String.format(
+                            "%s defines duplicate entries covering the same properties: %s", first.groupPath(), names));
+        }
+        return reported;
+    }
+
+    private <T> void collect(String basePath, String type, List<T> elements, Function<T, List<Object>> signatureFn) {
+        var groupPath = String.format("%s.%s", basePath, type);
+        for (int i = 0; i < elements.size(); i++) {
+            var element = elements.get(i);
+            var path = String.format("%s[%d]", groupPath, i);
+            definitions.add(new Definition(groupPath, signatureFn.apply(element), path, name(element)));
+        }
+    }
+
+    private static String name(Object element) {
+        if (element instanceof Constraint) {
+            return ((Constraint) element).getName();
+        }
+        if (element instanceof Index) {
+            return ((Index) element).getName();
+        }
+        throw new IllegalArgumentException("Unknown schema element type: " + element.getClass());
+    }
+
+    // Arrays.asList (unlike List.of) tolerates the null options/labels some definitions carry
+    private static List<Object> signature(Object... parts) {
+        return Arrays.asList(parts);
+    }
+
+    private static final class Definition {
+        private final String groupPath;
+        private final List<Object> signature;
+        private final String path;
+        private final String name;
+
+        Definition(String groupPath, List<Object> signature, String path, String name) {
+            this.groupPath = groupPath;
+            this.signature = signature;
+            this.path = path;
+            this.name = name;
+        }
+
+        String groupPath() {
+            return groupPath;
+        }
+
+        List<Object> signature() {
+            return signature;
+        }
+
+        String path() {
+            return path;
+        }
+
+        String name() {
+            return name;
+        }
+    }
+}

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndExistenceConstraintsValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndExistenceConstraintsValidator.java
@@ -46,7 +46,8 @@ public class NoRedundantKeyAndExistenceConstraintsValidator implements Specifica
                 NoDanglingLabelInExistenceConstraintValidator.class,
                 NoDanglingLabelInKeyConstraintValidator.class,
                 NoDanglingPropertyInExistenceConstraintValidator.class,
-                NoDanglingPropertyInKeyConstraintValidator.class);
+                NoDanglingPropertyInKeyConstraintValidator.class,
+                NoDuplicatedSchemaDefinitionValidator.class);
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndExistenceConstraintsValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndExistenceConstraintsValidator.java
@@ -16,28 +16,21 @@
  */
 package org.neo4j.importer.v1.validation.plugin;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.neo4j.importer.v1.targets.NodeTarget;
 import org.neo4j.importer.v1.targets.RelationshipTarget;
-import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
 import org.neo4j.importer.v1.validation.SpecificationValidator;
 
 // for the same label/type, any subset of the key properties also matched by an existence constraint constitute a
 // redundancy.
 // while the database allows this, import-spec forbids it
-public class NoRedundantKeyAndExistenceConstraintsValidator implements SpecificationValidator {
+public class NoRedundantKeyAndExistenceConstraintsValidator extends AbstractRedundantSchemaValidator {
 
     private static final String ERROR_CODE = "NRDC-001";
 
-    private final Map<String, List<List<String>>> invalidPaths;
-
     public NoRedundantKeyAndExistenceConstraintsValidator() {
-        this.invalidPaths = new LinkedHashMap<>();
+        super(ERROR_CODE, "key and existence constraints");
     }
 
     @Override
@@ -53,33 +46,18 @@ public class NoRedundantKeyAndExistenceConstraintsValidator implements Specifica
     @Override
     public void visitNodeTarget(int index, NodeTarget target) {
         var schema = target.getSchema();
-        var existencePaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
-        var existenceBasePath = String.format("$.targets.nodes[%d].schema.existence_constraints", index);
-        var existenceConstraints = schema.getExistenceConstraints();
-        for (int i = 0; i < existenceConstraints.size(); i++) {
-            var constraint = existenceConstraints.get(i);
-            var labelAndProp = new SchemaNodePattern(constraint.getLabel(), constraint.getProperty());
-            existencePaths
-                    .computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", existenceBasePath, i));
-        }
-        var keyPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
-        var keyBasePath = String.format("$.targets.nodes[%d].schema.key_constraints", index);
-        var keyConstraints = schema.getKeyConstraints();
-        for (int i = 0; i < keyConstraints.size(); i++) {
-            var constraint = keyConstraints.get(i);
-            for (String property : constraint.getProperties()) {
-                var labelAndProp = new SchemaNodePattern(constraint.getLabel(), property);
-                keyPaths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
-                        .add(String.format("%s[%d]", keyBasePath, i));
-            }
-        }
-        var redundancies = redundancies(existencePaths, keyPaths);
-
-        if (!redundancies.isEmpty()) {
-            var schemaPath = String.format("$.targets.nodes[%d].schema", index);
-            invalidPaths.put(schemaPath, redundancies);
-        }
+        var existencePaths = index(
+                schema.getExistenceConstraints(),
+                String.format("$.targets.nodes[%d].schema.existence_constraints", index),
+                (constraint) -> new SchemaNodePattern(constraint.getLabel(), constraint.getProperty()));
+        // a key constraint is redundant per individual property it shares with an existence constraint
+        var keyPaths = indexMulti(
+                schema.getKeyConstraints(),
+                String.format("$.targets.nodes[%d].schema.key_constraints", index),
+                (constraint) -> constraint.getProperties().stream()
+                        .map((property) -> new SchemaNodePattern(constraint.getLabel(), property))
+                        .collect(Collectors.toList()));
+        recordRedundancies(String.format("$.targets.nodes[%d].schema", index), redundancies(existencePaths, keyPaths));
     }
 
     @Override
@@ -88,61 +66,16 @@ public class NoRedundantKeyAndExistenceConstraintsValidator implements Specifica
         if (schema.isEmpty()) {
             return;
         }
-        var existencePaths = new LinkedHashMap<String, List<String>>();
-        var existenceBasePath = String.format("$.targets.relationships[%d].schema.existence_constraints", index);
-        var existenceConstraints = schema.getExistenceConstraints();
-        for (int i = 0; i < existenceConstraints.size(); i++) {
-            var constraint = existenceConstraints.get(i);
-            existencePaths
-                    .computeIfAbsent(constraint.getProperty(), (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", existenceBasePath, i));
-        }
-        var keyPaths = new LinkedHashMap<String, List<String>>();
-        var keyBasePath = String.format("$.targets.relationships[%d].schema.key_constraints", index);
-        var keyConstraints = schema.getKeyConstraints();
-        for (int i = 0; i < keyConstraints.size(); i++) {
-            var constraint = keyConstraints.get(i);
-            for (String property : constraint.getProperties()) {
-                keyPaths.computeIfAbsent(property, (key) -> new ArrayList<>(1))
-                        .add(String.format("%s[%d]", keyBasePath, i));
-            }
-        }
-        var redundancies = redundancies(existencePaths, keyPaths);
-
-        if (!redundancies.isEmpty()) {
-            var schemaPath = String.format("$.targets.relationships[%d].schema", index);
-            invalidPaths.put(schemaPath, redundancies);
-        }
-    }
-
-    // a redundancy exists only when the same label/property (or property, for relationships) is covered by both an
-    // existence constraint and a key constraint. Two key constraints sharing a property are not redundant.
-    private static <K> List<List<String>> redundancies(
-            Map<K, List<String>> existencePaths, Map<K, List<String>> keyPaths) {
-        var redundancies = new ArrayList<List<String>>();
-        existencePaths.forEach((pattern, existenceDefinitions) -> {
-            var keyDefinitions = keyPaths.get(pattern);
-            if (keyDefinitions != null) {
-                var redundantDefinitions = new ArrayList<String>(existenceDefinitions.size() + keyDefinitions.size());
-                redundantDefinitions.addAll(existenceDefinitions);
-                redundantDefinitions.addAll(keyDefinitions);
-                redundancies.add(redundantDefinitions);
-            }
-        });
-        return redundancies;
-    }
-
-    @Override
-    public boolean report(Builder builder) {
-        invalidPaths.forEach((schemaPath, redundancies) -> redundancies.forEach((redundantDefinitions) -> {
-            String redundantDefs = redundantDefinitions.stream()
-                    .map(def -> def.replace(schemaPath + ".", ""))
-                    .collect(Collectors.joining(", "));
-            builder.addError(
-                    schemaPath,
-                    ERROR_CODE,
-                    String.format("%s defines redundant key and existence constraints: %s", schemaPath, redundantDefs));
-        }));
-        return !invalidPaths.isEmpty();
+        var existencePaths = index(
+                schema.getExistenceConstraints(),
+                String.format("$.targets.relationships[%d].schema.existence_constraints", index),
+                (constraint) -> constraint.getProperty());
+        // a key constraint is redundant per individual property it shares with an existence constraint
+        var keyPaths = indexMulti(
+                schema.getKeyConstraints(),
+                String.format("$.targets.relationships[%d].schema.key_constraints", index),
+                (constraint) -> constraint.getProperties());
+        recordRedundancies(
+                String.format("$.targets.relationships[%d].schema", index), redundancies(existencePaths, keyPaths));
     }
 }

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndUniqueConstraintsValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndUniqueConstraintsValidator.java
@@ -48,31 +48,33 @@ public class NoRedundantKeyAndUniqueConstraintsValidator implements Specificatio
                 NoDanglingLabelInUniqueConstraintValidator.class,
                 NoDanglingLabelInKeyConstraintValidator.class,
                 NoDanglingPropertyInUniqueConstraintValidator.class,
-                NoDanglingPropertyInKeyConstraintValidator.class);
+                NoDanglingPropertyInKeyConstraintValidator.class,
+                NoDuplicatedSchemaDefinitionValidator.class);
     }
 
     @Override
     public void visitNodeTarget(int index, NodeTarget target) {
         var schema = target.getSchema();
-        var paths = new LinkedHashMap<SchemaNodePattern, List<String>>();
+        var uniquePaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
         var uniqueBasePath = String.format("$.targets.nodes[%d].schema.unique_constraints", index);
         var uniqueConstraints = schema.getUniqueConstraints();
         for (int i = 0; i < uniqueConstraints.size(); i++) {
             var constraint = uniqueConstraints.get(i);
             var labelAndProps = new SchemaNodePattern(constraint.getLabel(), constraint.getProperties());
-            paths.computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
+            uniquePaths
+                    .computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", uniqueBasePath, i));
         }
+        var keyPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
         var keyBasePath = String.format("$.targets.nodes[%d].schema.key_constraints", index);
         var keyConstraints = schema.getKeyConstraints();
         for (int i = 0; i < keyConstraints.size(); i++) {
             var constraint = keyConstraints.get(i);
             var labelAndProp = new SchemaNodePattern(constraint.getLabel(), constraint.getProperties());
-            paths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
+            keyPaths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", keyBasePath, i));
         }
-        List<List<String>> redundancies =
-                paths.values().stream().filter(allPaths -> allPaths.size() > 1).collect(Collectors.toList());
+        var redundancies = redundancies(uniquePaths, keyPaths);
 
         if (!redundancies.isEmpty()) {
             var schemaPath = String.format("$.targets.nodes[%d].schema", index);
@@ -86,28 +88,47 @@ public class NoRedundantKeyAndUniqueConstraintsValidator implements Specificatio
         if (schema.isEmpty()) {
             return;
         }
-        var paths = new LinkedHashMap<List<String>, List<String>>();
+        var uniquePaths = new LinkedHashMap<List<String>, List<String>>();
         var uniqueBasePath = String.format("$.targets.relationships[%d].schema.unique_constraints", index);
         var uniqueConstraints = schema.getUniqueConstraints();
         for (int i = 0; i < uniqueConstraints.size(); i++) {
             var constraint = uniqueConstraints.get(i);
-            paths.computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
+            uniquePaths
+                    .computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", uniqueBasePath, i));
         }
+        var keyPaths = new LinkedHashMap<List<String>, List<String>>();
         var keyBasePath = String.format("$.targets.relationships[%d].schema.key_constraints", index);
         var keyConstraints = schema.getKeyConstraints();
         for (int i = 0; i < keyConstraints.size(); i++) {
             var constraint = keyConstraints.get(i);
-            paths.computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
+            keyPaths.computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", keyBasePath, i));
         }
-        List<List<String>> redundancies =
-                paths.values().stream().filter(allPaths -> allPaths.size() > 1).collect(Collectors.toList());
+        var redundancies = redundancies(uniquePaths, keyPaths);
 
         if (!redundancies.isEmpty()) {
             var schemaPath = String.format("$.targets.relationships[%d].schema", index);
             invalidPaths.put(schemaPath, redundancies);
         }
+    }
+
+    // a redundancy exists only when the same label/properties (or properties, for relationships) is covered by both a
+    // unique constraint and a key constraint. Two constraints of the same kind sharing the same properties are not
+    // reported here.
+    private static <K> List<List<String>> redundancies(
+            Map<K, List<String>> uniquePaths, Map<K, List<String>> keyPaths) {
+        var redundancies = new ArrayList<List<String>>();
+        uniquePaths.forEach((pattern, uniqueDefinitions) -> {
+            var keyDefinitions = keyPaths.get(pattern);
+            if (keyDefinitions != null) {
+                var redundantDefinitions = new ArrayList<String>(uniqueDefinitions.size() + keyDefinitions.size());
+                redundantDefinitions.addAll(uniqueDefinitions);
+                redundantDefinitions.addAll(keyDefinitions);
+                redundancies.add(redundantDefinitions);
+            }
+        });
+        return redundancies;
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndUniqueConstraintsValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyAndUniqueConstraintsValidator.java
@@ -16,15 +16,9 @@
  */
 package org.neo4j.importer.v1.validation.plugin;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.neo4j.importer.v1.targets.NodeTarget;
 import org.neo4j.importer.v1.targets.RelationshipTarget;
-import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
 import org.neo4j.importer.v1.validation.SpecificationValidator;
 
 // for the same label/type, key properties matched **exactly** with a unique constraint constitute a redundancy.
@@ -32,14 +26,12 @@ import org.neo4j.importer.v1.validation.SpecificationValidator;
 // planner):
 // - a subset of the key properties are also defined as unique (and vice versa)
 // - key properties are also defined as unique but in different order
-public class NoRedundantKeyAndUniqueConstraintsValidator implements SpecificationValidator {
+public class NoRedundantKeyAndUniqueConstraintsValidator extends AbstractRedundantSchemaValidator {
 
     private static final String ERROR_CODE = "NRDC-002";
 
-    private final Map<String, List<List<String>>> invalidPaths;
-
     public NoRedundantKeyAndUniqueConstraintsValidator() {
-        this.invalidPaths = new LinkedHashMap<>();
+        super(ERROR_CODE, "key and unique constraints");
     }
 
     @Override
@@ -55,31 +47,15 @@ public class NoRedundantKeyAndUniqueConstraintsValidator implements Specificatio
     @Override
     public void visitNodeTarget(int index, NodeTarget target) {
         var schema = target.getSchema();
-        var uniquePaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
-        var uniqueBasePath = String.format("$.targets.nodes[%d].schema.unique_constraints", index);
-        var uniqueConstraints = schema.getUniqueConstraints();
-        for (int i = 0; i < uniqueConstraints.size(); i++) {
-            var constraint = uniqueConstraints.get(i);
-            var labelAndProps = new SchemaNodePattern(constraint.getLabel(), constraint.getProperties());
-            uniquePaths
-                    .computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", uniqueBasePath, i));
-        }
-        var keyPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
-        var keyBasePath = String.format("$.targets.nodes[%d].schema.key_constraints", index);
-        var keyConstraints = schema.getKeyConstraints();
-        for (int i = 0; i < keyConstraints.size(); i++) {
-            var constraint = keyConstraints.get(i);
-            var labelAndProp = new SchemaNodePattern(constraint.getLabel(), constraint.getProperties());
-            keyPaths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", keyBasePath, i));
-        }
-        var redundancies = redundancies(uniquePaths, keyPaths);
-
-        if (!redundancies.isEmpty()) {
-            var schemaPath = String.format("$.targets.nodes[%d].schema", index);
-            invalidPaths.put(schemaPath, redundancies);
-        }
+        var uniquePaths = index(
+                schema.getUniqueConstraints(),
+                String.format("$.targets.nodes[%d].schema.unique_constraints", index),
+                (constraint) -> new SchemaNodePattern(constraint.getLabel(), constraint.getProperties()));
+        var keyPaths = index(
+                schema.getKeyConstraints(),
+                String.format("$.targets.nodes[%d].schema.key_constraints", index),
+                (constraint) -> new SchemaNodePattern(constraint.getLabel(), constraint.getProperties()));
+        recordRedundancies(String.format("$.targets.nodes[%d].schema", index), redundancies(uniquePaths, keyPaths));
     }
 
     @Override
@@ -88,60 +64,15 @@ public class NoRedundantKeyAndUniqueConstraintsValidator implements Specificatio
         if (schema.isEmpty()) {
             return;
         }
-        var uniquePaths = new LinkedHashMap<List<String>, List<String>>();
-        var uniqueBasePath = String.format("$.targets.relationships[%d].schema.unique_constraints", index);
-        var uniqueConstraints = schema.getUniqueConstraints();
-        for (int i = 0; i < uniqueConstraints.size(); i++) {
-            var constraint = uniqueConstraints.get(i);
-            uniquePaths
-                    .computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", uniqueBasePath, i));
-        }
-        var keyPaths = new LinkedHashMap<List<String>, List<String>>();
-        var keyBasePath = String.format("$.targets.relationships[%d].schema.key_constraints", index);
-        var keyConstraints = schema.getKeyConstraints();
-        for (int i = 0; i < keyConstraints.size(); i++) {
-            var constraint = keyConstraints.get(i);
-            keyPaths.computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", keyBasePath, i));
-        }
-        var redundancies = redundancies(uniquePaths, keyPaths);
-
-        if (!redundancies.isEmpty()) {
-            var schemaPath = String.format("$.targets.relationships[%d].schema", index);
-            invalidPaths.put(schemaPath, redundancies);
-        }
-    }
-
-    // a redundancy exists only when the same label/properties (or properties, for relationships) is covered by both a
-    // unique constraint and a key constraint. Two constraints of the same kind sharing the same properties are not
-    // reported here.
-    private static <K> List<List<String>> redundancies(
-            Map<K, List<String>> uniquePaths, Map<K, List<String>> keyPaths) {
-        var redundancies = new ArrayList<List<String>>();
-        uniquePaths.forEach((pattern, uniqueDefinitions) -> {
-            var keyDefinitions = keyPaths.get(pattern);
-            if (keyDefinitions != null) {
-                var redundantDefinitions = new ArrayList<String>(uniqueDefinitions.size() + keyDefinitions.size());
-                redundantDefinitions.addAll(uniqueDefinitions);
-                redundantDefinitions.addAll(keyDefinitions);
-                redundancies.add(redundantDefinitions);
-            }
-        });
-        return redundancies;
-    }
-
-    @Override
-    public boolean report(Builder builder) {
-        invalidPaths.forEach((schemaPath, redundancies) -> redundancies.forEach((redundantDefinitions) -> {
-            String redundantDefs = redundantDefinitions.stream()
-                    .map(def -> def.replace(schemaPath + ".", ""))
-                    .collect(Collectors.joining(", "));
-            builder.addError(
-                    schemaPath,
-                    ERROR_CODE,
-                    String.format("%s defines redundant key and unique constraints: %s", schemaPath, redundantDefs));
-        }));
-        return !invalidPaths.isEmpty();
+        var uniquePaths = index(
+                schema.getUniqueConstraints(),
+                String.format("$.targets.relationships[%d].schema.unique_constraints", index),
+                (constraint) -> constraint.getProperties());
+        var keyPaths = index(
+                schema.getKeyConstraints(),
+                String.format("$.targets.relationships[%d].schema.key_constraints", index),
+                (constraint) -> constraint.getProperties());
+        recordRedundancies(
+                String.format("$.targets.relationships[%d].schema", index), redundancies(uniquePaths, keyPaths));
     }
 }

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyConstraintAndRangeIndexValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyConstraintAndRangeIndexValidator.java
@@ -43,31 +43,33 @@ public class NoRedundantKeyConstraintAndRangeIndexValidator implements Specifica
                 NoDanglingLabelInRangeIndexValidator.class,
                 NoDanglingLabelInKeyConstraintValidator.class,
                 NoDanglingPropertyInRangeIndexValidator.class,
-                NoDanglingPropertyInKeyConstraintValidator.class);
+                NoDanglingPropertyInKeyConstraintValidator.class,
+                NoDuplicatedSchemaDefinitionValidator.class);
     }
 
     @Override
     public void visitNodeTarget(int index, NodeTarget target) {
         var schema = target.getSchema();
-        var paths = new LinkedHashMap<SchemaNodePattern, List<String>>();
+        var rangeIndexPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
         var rangeIndexBasePath = String.format("$.targets.nodes[%d].schema.range_indexes", index);
         var rangeIndexes = schema.getRangeIndexes();
         for (int i = 0; i < rangeIndexes.size(); i++) {
             var rangeIndex = rangeIndexes.get(i);
             var labelAndProps = new SchemaNodePattern(rangeIndex.getLabel(), rangeIndex.getProperties());
-            paths.computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
+            rangeIndexPaths
+                    .computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", rangeIndexBasePath, i));
         }
+        var keyPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
         var keyBasePath = String.format("$.targets.nodes[%d].schema.key_constraints", index);
         var keyConstraints = schema.getKeyConstraints();
         for (int i = 0; i < keyConstraints.size(); i++) {
             var constraint = keyConstraints.get(i);
             var labelAndProp = new SchemaNodePattern(constraint.getLabel(), constraint.getProperties());
-            paths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
+            keyPaths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", keyBasePath, i));
         }
-        List<List<String>> redundancies =
-                paths.values().stream().filter(allPaths -> allPaths.size() > 1).collect(Collectors.toList());
+        var redundancies = redundancies(rangeIndexPaths, keyPaths);
 
         if (!redundancies.isEmpty()) {
             var schemaPath = String.format("$.targets.nodes[%d].schema", index);
@@ -81,28 +83,47 @@ public class NoRedundantKeyConstraintAndRangeIndexValidator implements Specifica
         if (schema.isEmpty()) {
             return;
         }
-        var paths = new LinkedHashMap<List<String>, List<String>>();
+        var rangeIndexPaths = new LinkedHashMap<List<String>, List<String>>();
         var rangeIndexBasePath = String.format("$.targets.relationships[%d].schema.range_indexes", index);
         var rangeIndexes = schema.getRangeIndexes();
         for (int i = 0; i < rangeIndexes.size(); i++) {
             var rangeIndex = rangeIndexes.get(i);
-            paths.computeIfAbsent(rangeIndex.getProperties(), (key) -> new ArrayList<>(1))
+            rangeIndexPaths
+                    .computeIfAbsent(rangeIndex.getProperties(), (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", rangeIndexBasePath, i));
         }
+        var keyPaths = new LinkedHashMap<List<String>, List<String>>();
         var keyBasePath = String.format("$.targets.relationships[%d].schema.key_constraints", index);
         var keyConstraints = schema.getKeyConstraints();
         for (int i = 0; i < keyConstraints.size(); i++) {
             var constraint = keyConstraints.get(i);
-            paths.computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
+            keyPaths.computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", keyBasePath, i));
         }
-        List<List<String>> redundancies =
-                paths.values().stream().filter(allPaths -> allPaths.size() > 1).collect(Collectors.toList());
+        var redundancies = redundancies(rangeIndexPaths, keyPaths);
 
         if (!redundancies.isEmpty()) {
             var schemaPath = String.format("$.targets.relationships[%d].schema", index);
             invalidPaths.put(schemaPath, redundancies);
         }
+    }
+
+    // a redundancy exists only when the same label/properties (or properties, for relationships) is covered by both a
+    // range index and a key constraint. Two range indexes (or two key constraints) sharing the same properties are not
+    // reported here.
+    private static <K> List<List<String>> redundancies(
+            Map<K, List<String>> rangeIndexPaths, Map<K, List<String>> keyPaths) {
+        var redundancies = new ArrayList<List<String>>();
+        rangeIndexPaths.forEach((pattern, rangeIndexDefinitions) -> {
+            var keyDefinitions = keyPaths.get(pattern);
+            if (keyDefinitions != null) {
+                var redundantDefinitions = new ArrayList<String>(rangeIndexDefinitions.size() + keyDefinitions.size());
+                redundantDefinitions.addAll(rangeIndexDefinitions);
+                redundantDefinitions.addAll(keyDefinitions);
+                redundancies.add(redundantDefinitions);
+            }
+        });
+        return redundancies;
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyConstraintAndRangeIndexValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantKeyConstraintAndRangeIndexValidator.java
@@ -16,25 +16,17 @@
  */
 package org.neo4j.importer.v1.validation.plugin;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.neo4j.importer.v1.targets.NodeTarget;
 import org.neo4j.importer.v1.targets.RelationshipTarget;
-import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
 import org.neo4j.importer.v1.validation.SpecificationValidator;
 
-public class NoRedundantKeyConstraintAndRangeIndexValidator implements SpecificationValidator {
+public class NoRedundantKeyConstraintAndRangeIndexValidator extends AbstractRedundantSchemaValidator {
 
     private static final String ERROR_CODE = "NRDC-003";
 
-    private final Map<String, List<List<String>>> invalidPaths;
-
     public NoRedundantKeyConstraintAndRangeIndexValidator() {
-        this.invalidPaths = new LinkedHashMap<>();
+        super(ERROR_CODE, "key constraint and range index");
     }
 
     @Override
@@ -50,31 +42,15 @@ public class NoRedundantKeyConstraintAndRangeIndexValidator implements Specifica
     @Override
     public void visitNodeTarget(int index, NodeTarget target) {
         var schema = target.getSchema();
-        var rangeIndexPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
-        var rangeIndexBasePath = String.format("$.targets.nodes[%d].schema.range_indexes", index);
-        var rangeIndexes = schema.getRangeIndexes();
-        for (int i = 0; i < rangeIndexes.size(); i++) {
-            var rangeIndex = rangeIndexes.get(i);
-            var labelAndProps = new SchemaNodePattern(rangeIndex.getLabel(), rangeIndex.getProperties());
-            rangeIndexPaths
-                    .computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", rangeIndexBasePath, i));
-        }
-        var keyPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
-        var keyBasePath = String.format("$.targets.nodes[%d].schema.key_constraints", index);
-        var keyConstraints = schema.getKeyConstraints();
-        for (int i = 0; i < keyConstraints.size(); i++) {
-            var constraint = keyConstraints.get(i);
-            var labelAndProp = new SchemaNodePattern(constraint.getLabel(), constraint.getProperties());
-            keyPaths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", keyBasePath, i));
-        }
-        var redundancies = redundancies(rangeIndexPaths, keyPaths);
-
-        if (!redundancies.isEmpty()) {
-            var schemaPath = String.format("$.targets.nodes[%d].schema", index);
-            invalidPaths.put(schemaPath, redundancies);
-        }
+        var rangeIndexPaths = index(
+                schema.getRangeIndexes(),
+                String.format("$.targets.nodes[%d].schema.range_indexes", index),
+                (rangeIndex) -> new SchemaNodePattern(rangeIndex.getLabel(), rangeIndex.getProperties()));
+        var keyPaths = index(
+                schema.getKeyConstraints(),
+                String.format("$.targets.nodes[%d].schema.key_constraints", index),
+                (constraint) -> new SchemaNodePattern(constraint.getLabel(), constraint.getProperties()));
+        recordRedundancies(String.format("$.targets.nodes[%d].schema", index), redundancies(rangeIndexPaths, keyPaths));
     }
 
     @Override
@@ -83,61 +59,15 @@ public class NoRedundantKeyConstraintAndRangeIndexValidator implements Specifica
         if (schema.isEmpty()) {
             return;
         }
-        var rangeIndexPaths = new LinkedHashMap<List<String>, List<String>>();
-        var rangeIndexBasePath = String.format("$.targets.relationships[%d].schema.range_indexes", index);
-        var rangeIndexes = schema.getRangeIndexes();
-        for (int i = 0; i < rangeIndexes.size(); i++) {
-            var rangeIndex = rangeIndexes.get(i);
-            rangeIndexPaths
-                    .computeIfAbsent(rangeIndex.getProperties(), (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", rangeIndexBasePath, i));
-        }
-        var keyPaths = new LinkedHashMap<List<String>, List<String>>();
-        var keyBasePath = String.format("$.targets.relationships[%d].schema.key_constraints", index);
-        var keyConstraints = schema.getKeyConstraints();
-        for (int i = 0; i < keyConstraints.size(); i++) {
-            var constraint = keyConstraints.get(i);
-            keyPaths.computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", keyBasePath, i));
-        }
-        var redundancies = redundancies(rangeIndexPaths, keyPaths);
-
-        if (!redundancies.isEmpty()) {
-            var schemaPath = String.format("$.targets.relationships[%d].schema", index);
-            invalidPaths.put(schemaPath, redundancies);
-        }
-    }
-
-    // a redundancy exists only when the same label/properties (or properties, for relationships) is covered by both a
-    // range index and a key constraint. Two range indexes (or two key constraints) sharing the same properties are not
-    // reported here.
-    private static <K> List<List<String>> redundancies(
-            Map<K, List<String>> rangeIndexPaths, Map<K, List<String>> keyPaths) {
-        var redundancies = new ArrayList<List<String>>();
-        rangeIndexPaths.forEach((pattern, rangeIndexDefinitions) -> {
-            var keyDefinitions = keyPaths.get(pattern);
-            if (keyDefinitions != null) {
-                var redundantDefinitions = new ArrayList<String>(rangeIndexDefinitions.size() + keyDefinitions.size());
-                redundantDefinitions.addAll(rangeIndexDefinitions);
-                redundantDefinitions.addAll(keyDefinitions);
-                redundancies.add(redundantDefinitions);
-            }
-        });
-        return redundancies;
-    }
-
-    @Override
-    public boolean report(Builder builder) {
-        invalidPaths.forEach((schemaPath, redundancies) -> redundancies.forEach((redundantDefinitions) -> {
-            String redundantDefs = redundantDefinitions.stream()
-                    .map(def -> def.replace(schemaPath + ".", ""))
-                    .collect(Collectors.joining(", "));
-            builder.addError(
-                    schemaPath,
-                    ERROR_CODE,
-                    String.format(
-                            "%s defines redundant key constraint and range index: %s", schemaPath, redundantDefs));
-        }));
-        return !invalidPaths.isEmpty();
+        var rangeIndexPaths = index(
+                schema.getRangeIndexes(),
+                String.format("$.targets.relationships[%d].schema.range_indexes", index),
+                (rangeIndex) -> rangeIndex.getProperties());
+        var keyPaths = index(
+                schema.getKeyConstraints(),
+                String.format("$.targets.relationships[%d].schema.key_constraints", index),
+                (constraint) -> constraint.getProperties());
+        recordRedundancies(
+                String.format("$.targets.relationships[%d].schema", index), redundancies(rangeIndexPaths, keyPaths));
     }
 }

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantUniqueConstraintAndRangeIndexValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantUniqueConstraintAndRangeIndexValidator.java
@@ -16,25 +16,17 @@
  */
 package org.neo4j.importer.v1.validation.plugin;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.neo4j.importer.v1.targets.NodeTarget;
 import org.neo4j.importer.v1.targets.RelationshipTarget;
-import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
 import org.neo4j.importer.v1.validation.SpecificationValidator;
 
-public class NoRedundantUniqueConstraintAndRangeIndexValidator implements SpecificationValidator {
+public class NoRedundantUniqueConstraintAndRangeIndexValidator extends AbstractRedundantSchemaValidator {
 
     private static final String ERROR_CODE = "NRDC-004";
 
-    private final Map<String, List<List<String>>> invalidPaths;
-
     public NoRedundantUniqueConstraintAndRangeIndexValidator() {
-        this.invalidPaths = new LinkedHashMap<>();
+        super(ERROR_CODE, "unique constraint and range index");
     }
 
     @Override
@@ -50,32 +42,16 @@ public class NoRedundantUniqueConstraintAndRangeIndexValidator implements Specif
     @Override
     public void visitNodeTarget(int index, NodeTarget target) {
         var schema = target.getSchema();
-        var rangeIndexPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
-        var rangeIndexBasePath = String.format("$.targets.nodes[%d].schema.range_indexes", index);
-        var rangeIndexes = schema.getRangeIndexes();
-        for (int i = 0; i < rangeIndexes.size(); i++) {
-            var rangeIndex = rangeIndexes.get(i);
-            var labelAndProps = new SchemaNodePattern(rangeIndex.getLabel(), rangeIndex.getProperties());
-            rangeIndexPaths
-                    .computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", rangeIndexBasePath, i));
-        }
-        var uniquePaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
-        var uniqueBasePath = String.format("$.targets.nodes[%d].schema.unique_constraints", index);
-        var uniqueConstraints = schema.getUniqueConstraints();
-        for (int i = 0; i < uniqueConstraints.size(); i++) {
-            var constraint = uniqueConstraints.get(i);
-            var labelAndProp = new SchemaNodePattern(constraint.getLabel(), constraint.getProperties());
-            uniquePaths
-                    .computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", uniqueBasePath, i));
-        }
-        var redundancies = redundancies(rangeIndexPaths, uniquePaths);
-
-        if (!redundancies.isEmpty()) {
-            var schemaPath = String.format("$.targets.nodes[%d].schema", index);
-            invalidPaths.put(schemaPath, redundancies);
-        }
+        var rangeIndexPaths = index(
+                schema.getRangeIndexes(),
+                String.format("$.targets.nodes[%d].schema.range_indexes", index),
+                (rangeIndex) -> new SchemaNodePattern(rangeIndex.getLabel(), rangeIndex.getProperties()));
+        var uniquePaths = index(
+                schema.getUniqueConstraints(),
+                String.format("$.targets.nodes[%d].schema.unique_constraints", index),
+                (constraint) -> new SchemaNodePattern(constraint.getLabel(), constraint.getProperties()));
+        recordRedundancies(
+                String.format("$.targets.nodes[%d].schema", index), redundancies(rangeIndexPaths, uniquePaths));
     }
 
     @Override
@@ -84,63 +60,15 @@ public class NoRedundantUniqueConstraintAndRangeIndexValidator implements Specif
         if (schema.isEmpty()) {
             return;
         }
-        var rangeIndexPaths = new LinkedHashMap<List<String>, List<String>>();
-        var rangeIndexBasePath = String.format("$.targets.relationships[%d].schema.range_indexes", index);
-        var rangeIndexes = schema.getRangeIndexes();
-        for (int i = 0; i < rangeIndexes.size(); i++) {
-            var rangeIndex = rangeIndexes.get(i);
-            rangeIndexPaths
-                    .computeIfAbsent(rangeIndex.getProperties(), (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", rangeIndexBasePath, i));
-        }
-        var uniquePaths = new LinkedHashMap<List<String>, List<String>>();
-        var uniqueBasePath = String.format("$.targets.relationships[%d].schema.unique_constraints", index);
-        var uniqueConstraints = schema.getUniqueConstraints();
-        for (int i = 0; i < uniqueConstraints.size(); i++) {
-            var constraint = uniqueConstraints.get(i);
-            uniquePaths
-                    .computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
-                    .add(String.format("%s[%d]", uniqueBasePath, i));
-        }
-        var redundancies = redundancies(rangeIndexPaths, uniquePaths);
-
-        if (!redundancies.isEmpty()) {
-            var schemaPath = String.format("$.targets.relationships[%d].schema", index);
-            invalidPaths.put(schemaPath, redundancies);
-        }
-    }
-
-    // a redundancy exists only when the same label/properties (or properties, for relationships) is covered by both a
-    // range index and a unique constraint. Two range indexes (or two unique constraints) sharing the same properties
-    // are not reported here.
-    private static <K> List<List<String>> redundancies(
-            Map<K, List<String>> rangeIndexPaths, Map<K, List<String>> uniquePaths) {
-        var redundancies = new ArrayList<List<String>>();
-        rangeIndexPaths.forEach((pattern, rangeIndexDefinitions) -> {
-            var uniqueDefinitions = uniquePaths.get(pattern);
-            if (uniqueDefinitions != null) {
-                var redundantDefinitions =
-                        new ArrayList<String>(rangeIndexDefinitions.size() + uniqueDefinitions.size());
-                redundantDefinitions.addAll(rangeIndexDefinitions);
-                redundantDefinitions.addAll(uniqueDefinitions);
-                redundancies.add(redundantDefinitions);
-            }
-        });
-        return redundancies;
-    }
-
-    @Override
-    public boolean report(Builder builder) {
-        invalidPaths.forEach((schemaPath, redundancies) -> redundancies.forEach((redundantDefinitions) -> {
-            String redundantDefs = redundantDefinitions.stream()
-                    .map(def -> def.replace(schemaPath + ".", ""))
-                    .collect(Collectors.joining(", "));
-            builder.addError(
-                    schemaPath,
-                    ERROR_CODE,
-                    String.format(
-                            "%s defines redundant unique constraint and range index: %s", schemaPath, redundantDefs));
-        }));
-        return !invalidPaths.isEmpty();
+        var rangeIndexPaths = index(
+                schema.getRangeIndexes(),
+                String.format("$.targets.relationships[%d].schema.range_indexes", index),
+                (rangeIndex) -> rangeIndex.getProperties());
+        var uniquePaths = index(
+                schema.getUniqueConstraints(),
+                String.format("$.targets.relationships[%d].schema.unique_constraints", index),
+                (constraint) -> constraint.getProperties());
+        recordRedundancies(
+                String.format("$.targets.relationships[%d].schema", index), redundancies(rangeIndexPaths, uniquePaths));
     }
 }

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantUniqueConstraintAndRangeIndexValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoRedundantUniqueConstraintAndRangeIndexValidator.java
@@ -43,31 +43,34 @@ public class NoRedundantUniqueConstraintAndRangeIndexValidator implements Specif
                 NoDanglingLabelInRangeIndexValidator.class,
                 NoDanglingLabelInUniqueConstraintValidator.class,
                 NoDanglingPropertyInRangeIndexValidator.class,
-                NoDanglingPropertyInUniqueConstraintValidator.class);
+                NoDanglingPropertyInUniqueConstraintValidator.class,
+                NoDuplicatedSchemaDefinitionValidator.class);
     }
 
     @Override
     public void visitNodeTarget(int index, NodeTarget target) {
         var schema = target.getSchema();
-        var paths = new LinkedHashMap<SchemaNodePattern, List<String>>();
+        var rangeIndexPaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
         var rangeIndexBasePath = String.format("$.targets.nodes[%d].schema.range_indexes", index);
         var rangeIndexes = schema.getRangeIndexes();
         for (int i = 0; i < rangeIndexes.size(); i++) {
             var rangeIndex = rangeIndexes.get(i);
             var labelAndProps = new SchemaNodePattern(rangeIndex.getLabel(), rangeIndex.getProperties());
-            paths.computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
+            rangeIndexPaths
+                    .computeIfAbsent(labelAndProps, (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", rangeIndexBasePath, i));
         }
+        var uniquePaths = new LinkedHashMap<SchemaNodePattern, List<String>>();
         var uniqueBasePath = String.format("$.targets.nodes[%d].schema.unique_constraints", index);
         var uniqueConstraints = schema.getUniqueConstraints();
         for (int i = 0; i < uniqueConstraints.size(); i++) {
             var constraint = uniqueConstraints.get(i);
             var labelAndProp = new SchemaNodePattern(constraint.getLabel(), constraint.getProperties());
-            paths.computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
+            uniquePaths
+                    .computeIfAbsent(labelAndProp, (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", uniqueBasePath, i));
         }
-        List<List<String>> redundancies =
-                paths.values().stream().filter(allPaths -> allPaths.size() > 1).collect(Collectors.toList());
+        var redundancies = redundancies(rangeIndexPaths, uniquePaths);
 
         if (!redundancies.isEmpty()) {
             var schemaPath = String.format("$.targets.nodes[%d].schema", index);
@@ -81,28 +84,49 @@ public class NoRedundantUniqueConstraintAndRangeIndexValidator implements Specif
         if (schema.isEmpty()) {
             return;
         }
-        var paths = new LinkedHashMap<List<String>, List<String>>();
+        var rangeIndexPaths = new LinkedHashMap<List<String>, List<String>>();
         var rangeIndexBasePath = String.format("$.targets.relationships[%d].schema.range_indexes", index);
         var rangeIndexes = schema.getRangeIndexes();
         for (int i = 0; i < rangeIndexes.size(); i++) {
             var rangeIndex = rangeIndexes.get(i);
-            paths.computeIfAbsent(rangeIndex.getProperties(), (key) -> new ArrayList<>(1))
+            rangeIndexPaths
+                    .computeIfAbsent(rangeIndex.getProperties(), (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", rangeIndexBasePath, i));
         }
+        var uniquePaths = new LinkedHashMap<List<String>, List<String>>();
         var uniqueBasePath = String.format("$.targets.relationships[%d].schema.unique_constraints", index);
         var uniqueConstraints = schema.getUniqueConstraints();
         for (int i = 0; i < uniqueConstraints.size(); i++) {
             var constraint = uniqueConstraints.get(i);
-            paths.computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
+            uniquePaths
+                    .computeIfAbsent(constraint.getProperties(), (key) -> new ArrayList<>(1))
                     .add(String.format("%s[%d]", uniqueBasePath, i));
         }
-        List<List<String>> redundancies =
-                paths.values().stream().filter(allPaths -> allPaths.size() > 1).collect(Collectors.toList());
+        var redundancies = redundancies(rangeIndexPaths, uniquePaths);
 
         if (!redundancies.isEmpty()) {
             var schemaPath = String.format("$.targets.relationships[%d].schema", index);
             invalidPaths.put(schemaPath, redundancies);
         }
+    }
+
+    // a redundancy exists only when the same label/properties (or properties, for relationships) is covered by both a
+    // range index and a unique constraint. Two range indexes (or two unique constraints) sharing the same properties
+    // are not reported here.
+    private static <K> List<List<String>> redundancies(
+            Map<K, List<String>> rangeIndexPaths, Map<K, List<String>> uniquePaths) {
+        var redundancies = new ArrayList<List<String>>();
+        rangeIndexPaths.forEach((pattern, rangeIndexDefinitions) -> {
+            var uniqueDefinitions = uniquePaths.get(pattern);
+            if (uniqueDefinitions != null) {
+                var redundantDefinitions =
+                        new ArrayList<String>(rangeIndexDefinitions.size() + uniqueDefinitions.size());
+                redundantDefinitions.addAll(rangeIndexDefinitions);
+                redundantDefinitions.addAll(uniqueDefinitions);
+                redundancies.add(redundantDefinitions);
+            }
+        });
+        return redundancies;
     }
 
     @Override

--- a/core/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/core/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -32,6 +32,7 @@ org.neo4j.importer.v1.validation.plugin.NoDuplicatedDependencyValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedLabelInFullTextIndexValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedLabelValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedNameValidator
+org.neo4j.importer.v1.validation.plugin.NoDuplicatedSchemaDefinitionValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedSchemaNameValidator
 org.neo4j.importer.v1.validation.plugin.NoDuplicatedTargetPropertyValidator
 org.neo4j.importer.v1.validation.plugin.NoIncompleteNodeReferenceKeyMatchValidator

--- a/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -4810,6 +4810,129 @@ class ImportSpecificationDeserializerTest {
 
     @ParameterizedTest
     @EnumSource(SpecFormat.class)
+    void fails_if_node_unique_constraints_are_duplicated(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.unique_constraints defines duplicate entries covering the same properties: \"a unique constraint\", \"another unique constraint\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_relationship_unique_constraints_are_duplicated(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].schema.unique_constraints defines duplicate entries covering the same properties: \"a unique constraint\", \"another unique constraint\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_node_range_indexes_are_duplicated(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.range_indexes defines duplicate entries covering the same properties: \"a range index\", \"another range index\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_relationship_range_indexes_are_duplicated(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].schema.range_indexes defines duplicate entries covering the same properties: \"a range index\", \"another range index\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_node_key_constraints_are_duplicated(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.key_constraints defines duplicate entries covering the same properties: \"a key constraint\", \"another key constraint\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_relationship_key_constraints_are_duplicated(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].schema.key_constraints defines duplicate entries covering the same properties: \"a key constraint\", \"another key constraint\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    // https://neo4j.com/docs/cypher-manual/current/indexes/search-performance-indexes/using-indexes/#composite-indexes-property-order
+    void does_not_fail_if_node_unique_constraints_have_same_properties_in_different_order(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatCode(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void does_not_fail_if_node_unique_constraints_have_same_property_on_different_labels(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatCode(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
     void does_not_fail_if_relationship_references_node_via_shorter_overlapping_key_constraint(
             SpecFormat format, TestInfo testInfo) {
 

--- a/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -5011,6 +5011,125 @@ class ImportSpecificationDeserializerTest {
 
     @ParameterizedTest
     @EnumSource(SpecFormat.class)
+    void fails_if_only_one_of_many_node_key_and_unique_constraints_is_redundant(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema defines redundant key and unique constraints: unique_constraints[1], key_constraints[0]");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_only_one_of_many_relationship_key_and_unique_constraints_is_redundant(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].schema defines redundant key and unique constraints: unique_constraints[1], key_constraints[0]");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_node_key_and_multiple_unique_constraints_are_redundant(SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        // the two identical unique constraints are both redundant with the key constraint and
+                        // duplicates of each other, so both validators fire
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema.unique_constraints defines duplicate entries covering the same properties: \"a unique constraint\", \"another unique constraint\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_only_one_of_many_node_key_constraints_and_range_indexes_is_redundant(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema defines redundant key constraint and range index: range_indexes[1], key_constraints[0]");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_only_one_of_many_relationship_key_constraints_and_range_indexes_is_redundant(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].schema defines redundant key constraint and range index: range_indexes[1], key_constraints[0]");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_only_one_of_many_node_unique_constraints_and_range_indexes_is_redundant(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.nodes[0].schema defines redundant unique constraint and range index: range_indexes[1], unique_constraints[0]");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_only_one_of_many_relationship_unique_constraints_and_range_indexes_is_redundant(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "$.targets.relationships[0].schema defines redundant unique constraint and range index: range_indexes[1], unique_constraints[0]");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
     void does_not_fail_if_key_and_unique_constraints_are_defined_on_same_properties_but_different_labels(
             SpecFormat format, TestInfo testInfo) {
 

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_unique_constraints_have_same_properties_in_different_order.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_unique_constraints_have_same_properties_in_different_order.json
@@ -1,0 +1,28 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"}
+            ],
+            "schema": {
+                "unique_constraints": [
+                    {"name": "a unique constraint", "label": "Label", "properties": ["property1", "property2"]},
+                    {"name": "another unique constraint", "label": "Label", "properties": ["property2", "property1"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_unique_constraints_have_same_properties_in_different_order.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_unique_constraints_have_same_properties_in_different_order.yaml
@@ -1,0 +1,32 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    schema:
+      unique_constraints:
+      - name: a unique constraint
+        label: Label
+        properties:
+        - property1
+        - property2
+      - name: another unique constraint
+        label: Label
+        properties:
+        - property2
+        - property1

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_unique_constraints_have_same_property_on_different_labels.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_unique_constraints_have_same_property_on_different_labels.json
@@ -1,0 +1,27 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label1", "Label2"],
+            "properties": [
+                {"source_field": "id", "target_property": "property1"}
+            ],
+            "schema": {
+                "unique_constraints": [
+                    {"name": "a unique constraint", "label": "Label1", "properties": ["property1"]},
+                    {"name": "another unique constraint", "label": "Label2", "properties": ["property1"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_unique_constraints_have_same_property_on_different_labels.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_node_unique_constraints_have_same_property_on_different_labels.yaml
@@ -1,0 +1,29 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label1
+    - Label2
+    properties:
+    - source_field: id
+      target_property: property1
+    schema:
+      unique_constraints:
+      - name: a unique constraint
+        label: Label1
+        properties:
+        - property1
+      - name: another unique constraint
+        label: Label2
+        properties:
+        - property1

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_key_and_multiple_unique_constraints_are_redundant.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_key_and_multiple_unique_constraints_are_redundant.json
@@ -1,0 +1,31 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a key constraint", "label": "Label", "properties": ["property1", "property2"]}
+                ],
+                "unique_constraints": [
+                    {"name": "a unique constraint", "label": "Label", "properties": ["property1", "property2"]},
+                    {"name": "another unique constraint", "label": "Label", "properties": ["property1", "property2"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_key_and_multiple_unique_constraints_are_redundant.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_key_and_multiple_unique_constraints_are_redundant.yaml
@@ -1,0 +1,38 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    schema:
+      key_constraints:
+      - name: a key constraint
+        label: Label
+        properties:
+        - property1
+        - property2
+      unique_constraints:
+      - name: a unique constraint
+        label: Label
+        properties:
+        - property1
+        - property2
+      - name: another unique constraint
+        label: Label
+        properties:
+        - property1
+        - property2

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_key_constraints_are_duplicated.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_key_constraints_are_duplicated.json
@@ -1,0 +1,28 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "active": true,
+          "name": "a-target",
+          "source": "a-source",
+          "write_mode": "merge",
+          "labels": ["Label"],
+          "properties": [
+            {"source_field": "id", "target_property": "property1"}
+          ],
+          "schema": {
+              "key_constraints": [
+                 {"name": "a key constraint", "label": "Label", "properties": ["property1"]},
+                 {"name": "another key constraint", "label": "Label", "properties": ["property1"]}
+              ]
+          }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_key_constraints_are_duplicated.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_key_constraints_are_duplicated.yaml
@@ -1,0 +1,28 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    schema:
+      key_constraints:
+      - name: a key constraint
+        label: Label
+        properties:
+        - property1
+      - name: another key constraint
+        label: Label
+        properties:
+        - property1

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_range_indexes_are_duplicated.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_range_indexes_are_duplicated.json
@@ -1,0 +1,28 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "active": true,
+          "name": "a-target",
+          "source": "a-source",
+          "write_mode": "merge",
+          "labels": ["Label"],
+          "properties": [
+            {"source_field": "id", "target_property": "property1"}
+          ],
+          "schema": {
+              "range_indexes": [
+                 {"name": "a range index", "label": "Label", "properties": ["property1"]},
+                 {"name": "another range index", "label": "Label", "properties": ["property1"]}
+              ]
+          }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_range_indexes_are_duplicated.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_range_indexes_are_duplicated.yaml
@@ -1,0 +1,28 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    schema:
+      range_indexes:
+      - name: a range index
+        label: Label
+        properties:
+        - property1
+      - name: another range index
+        label: Label
+        properties:
+        - property1

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_unique_constraints_are_duplicated.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_unique_constraints_are_duplicated.json
@@ -1,0 +1,28 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "active": true,
+          "name": "a-target",
+          "source": "a-source",
+          "write_mode": "merge",
+          "labels": ["Label"],
+          "properties": [
+            {"source_field": "id", "target_property": "property1"}
+          ],
+          "schema": {
+              "unique_constraints": [
+                 {"name": "a unique constraint", "label": "Label", "properties": ["property1"]},
+                 {"name": "another unique constraint", "label": "Label", "properties": ["property1"]}
+              ]
+          }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_unique_constraints_are_duplicated.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_node_unique_constraints_are_duplicated.yaml
@@ -1,0 +1,28 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    schema:
+      unique_constraints:
+      - name: a unique constraint
+        label: Label
+        properties:
+        - property1
+      - name: another unique constraint
+        label: Label
+        properties:
+        - property1

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_key_and_unique_constraints_is_redundant.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_key_and_unique_constraints_is_redundant.json
@@ -1,0 +1,33 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name, extra FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"},
+                {"source_field": "extra", "target_property": "property3"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a key constraint", "label": "Label", "properties": ["property2", "property3"]},
+                    {"name": "another key constraint", "label": "Label", "properties": ["property1", "property2"]}
+                ],
+                "unique_constraints": [
+                    {"name": "a unique constraint", "label": "Label", "properties": ["property1"]},
+                    {"name": "another unique constraint", "label": "Label", "properties": ["property2", "property3"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_key_and_unique_constraints_is_redundant.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_key_and_unique_constraints_is_redundant.yaml
@@ -1,0 +1,44 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name, extra FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    - source_field: extra
+      target_property: property3
+    schema:
+      key_constraints:
+      - name: a key constraint
+        label: Label
+        properties:
+        - property2
+        - property3
+      - name: another key constraint
+        label: Label
+        properties:
+        - property1
+        - property2
+      unique_constraints:
+      - name: a unique constraint
+        label: Label
+        properties:
+        - property1
+      - name: another unique constraint
+        label: Label
+        properties:
+        - property2
+        - property3

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_key_constraints_and_range_indexes_is_redundant.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_key_constraints_and_range_indexes_is_redundant.json
@@ -1,0 +1,33 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name, extra FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"},
+                {"source_field": "extra", "target_property": "property3"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a key constraint", "label": "Label", "properties": ["property2", "property3"]},
+                    {"name": "another key constraint", "label": "Label", "properties": ["property1", "property2"]}
+                ],
+                "range_indexes": [
+                    {"name": "a range index", "label": "Label", "properties": ["property1"]},
+                    {"name": "another range index", "label": "Label", "properties": ["property2", "property3"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_key_constraints_and_range_indexes_is_redundant.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_key_constraints_and_range_indexes_is_redundant.yaml
@@ -1,0 +1,44 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name, extra FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    - source_field: extra
+      target_property: property3
+    schema:
+      key_constraints:
+      - name: a key constraint
+        label: Label
+        properties:
+        - property2
+        - property3
+      - name: another key constraint
+        label: Label
+        properties:
+        - property1
+        - property2
+      range_indexes:
+      - name: a range index
+        label: Label
+        properties:
+        - property1
+      - name: another range index
+        label: Label
+        properties:
+        - property2
+        - property3

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_unique_constraints_and_range_indexes_is_redundant.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_unique_constraints_and_range_indexes_is_redundant.json
@@ -1,0 +1,33 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name, extra FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "active": true,
+            "name": "a-target",
+            "source": "a-source",
+            "write_mode": "merge",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"},
+                {"source_field": "extra", "target_property": "property3"}
+            ],
+            "schema": {
+                "unique_constraints": [
+                    {"name": "a unique constraint", "label": "Label", "properties": ["property2", "property3"]},
+                    {"name": "another unique constraint", "label": "Label", "properties": ["property1", "property2"]}
+                ],
+                "range_indexes": [
+                    {"name": "a range index", "label": "Label", "properties": ["property1"]},
+                    {"name": "another range index", "label": "Label", "properties": ["property2", "property3"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_unique_constraints_and_range_indexes_is_redundant.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_node_unique_constraints_and_range_indexes_is_redundant.yaml
@@ -1,0 +1,44 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name, extra FROM my.table
+targets:
+  nodes:
+  - active: true
+    name: a-target
+    source: a-source
+    write_mode: merge
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    - source_field: extra
+      target_property: property3
+    schema:
+      unique_constraints:
+      - name: a unique constraint
+        label: Label
+        properties:
+        - property2
+        - property3
+      - name: another unique constraint
+        label: Label
+        properties:
+        - property1
+        - property2
+      range_indexes:
+      - name: a range index
+        label: Label
+        properties:
+        - property1
+      - name: another range index
+        label: Label
+        properties:
+        - property2
+        - property3

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_key_and_unique_constraints_is_redundant.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_key_and_unique_constraints_is_redundant.json
@@ -1,0 +1,46 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name, extra FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a-key-constraint", "label": "Label", "properties": ["id"]}
+                ]
+            }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"},
+                {"source_field": "extra", "target_property": "property3"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a key constraint", "properties": ["property2", "property3"]},
+                    {"name": "another key constraint", "properties": ["property1", "property2"]}
+                ],
+                "unique_constraints": [
+                    {"name": "a unique constraint", "properties": ["property1"]},
+                    {"name": "another unique constraint", "properties": ["property2", "property3"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_key_and_unique_constraints_is_redundant.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_key_and_unique_constraints_is_redundant.yaml
@@ -1,0 +1,53 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name, extra FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: a-key-constraint
+        label: Label
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    - source_field: extra
+      target_property: property3
+    schema:
+      key_constraints:
+      - name: a key constraint
+        properties:
+        - property2
+        - property3
+      - name: another key constraint
+        properties:
+        - property1
+        - property2
+      unique_constraints:
+      - name: a unique constraint
+        properties:
+        - property1
+      - name: another unique constraint
+        properties:
+        - property2
+        - property3

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_key_constraints_and_range_indexes_is_redundant.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_key_constraints_and_range_indexes_is_redundant.json
@@ -1,0 +1,46 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name, extra FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a-key-constraint", "label": "Label", "properties": ["id"]}
+                ]
+            }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"},
+                {"source_field": "extra", "target_property": "property3"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a key constraint", "properties": ["property2", "property3"]},
+                    {"name": "another key constraint", "properties": ["property1", "property2"]}
+                ],
+                "range_indexes": [
+                    {"name": "a range index", "properties": ["property1"]},
+                    {"name": "another range index", "properties": ["property2", "property3"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_key_constraints_and_range_indexes_is_redundant.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_key_constraints_and_range_indexes_is_redundant.yaml
@@ -1,0 +1,53 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name, extra FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: a-key-constraint
+        label: Label
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    - source_field: extra
+      target_property: property3
+    schema:
+      key_constraints:
+      - name: a key constraint
+        properties:
+        - property2
+        - property3
+      - name: another key constraint
+        properties:
+        - property1
+        - property2
+      range_indexes:
+      - name: a range index
+        properties:
+        - property1
+      - name: another range index
+        properties:
+        - property2
+        - property3

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_unique_constraints_and_range_indexes_is_redundant.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_unique_constraints_and_range_indexes_is_redundant.json
@@ -1,0 +1,46 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name, extra FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a-key-constraint", "label": "Label", "properties": ["id"]}
+                ]
+            }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "property1"},
+                {"source_field": "name", "target_property": "property2"},
+                {"source_field": "extra", "target_property": "property3"}
+            ],
+            "schema": {
+                "unique_constraints": [
+                    {"name": "a unique constraint", "properties": ["property2", "property3"]},
+                    {"name": "another unique constraint", "properties": ["property1", "property2"]}
+                ],
+                "range_indexes": [
+                    {"name": "a range index", "properties": ["property1"]},
+                    {"name": "another range index", "properties": ["property2", "property3"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_unique_constraints_and_range_indexes_is_redundant.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_only_one_of_many_relationship_unique_constraints_and_range_indexes_is_redundant.yaml
@@ -1,0 +1,53 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name, extra FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: a-key-constraint
+        label: Label
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target
+    properties:
+    - source_field: id
+      target_property: property1
+    - source_field: name
+      target_property: property2
+    - source_field: extra
+      target_property: property3
+    schema:
+      unique_constraints:
+      - name: a unique constraint
+        properties:
+        - property2
+        - property3
+      - name: another unique constraint
+        properties:
+        - property1
+        - property2
+      range_indexes:
+      - name: a range index
+        properties:
+        - property1
+      - name: another range index
+        properties:
+        - property2
+        - property3

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_key_constraints_are_duplicated.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_key_constraints_are_duplicated.json
@@ -1,0 +1,43 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "name": "a-node-target",
+          "source": "a-source",
+          "labels": ["Label"],
+          "properties": [
+            {"source_field": "id", "target_property": "id"}
+          ],
+          "schema": {
+              "key_constraints": [{
+                 "name": "a-key-constraint",
+                 "label": "Label",
+                 "properties": ["id"]
+              }]
+          }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "property1"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "a key constraint", "properties": ["property1"]},
+                    {"name": "another key constraint", "properties": ["property1"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_key_constraints_are_duplicated.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_key_constraints_are_duplicated.yaml
@@ -1,0 +1,39 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: a-key-constraint
+        label: Label
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target
+    properties:
+    - source_field: id
+      target_property: property1
+    schema:
+      key_constraints:
+      - name: a key constraint
+        properties:
+        - property1
+      - name: another key constraint
+        properties:
+        - property1

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_range_indexes_are_duplicated.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_range_indexes_are_duplicated.json
@@ -1,0 +1,43 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "name": "a-node-target",
+          "source": "a-source",
+          "labels": ["Label"],
+          "properties": [
+            {"source_field": "id", "target_property": "id"}
+          ],
+          "schema": {
+              "key_constraints": [{
+                 "name": "a-key-constraint",
+                 "label": "Label",
+                 "properties": ["id"]
+              }]
+          }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "property1"}
+            ],
+            "schema": {
+                "range_indexes": [
+                    {"name": "a range index", "properties": ["property1"]},
+                    {"name": "another range index", "properties": ["property1"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_range_indexes_are_duplicated.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_range_indexes_are_duplicated.yaml
@@ -1,0 +1,39 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: a-key-constraint
+        label: Label
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target
+    properties:
+    - source_field: id
+      target_property: property1
+    schema:
+      range_indexes:
+      - name: a range index
+        properties:
+        - property1
+      - name: another range index
+        properties:
+        - property1

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_unique_constraints_are_duplicated.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_unique_constraints_are_duplicated.json
@@ -1,0 +1,43 @@
+
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+          "name": "a-node-target",
+          "source": "a-source",
+          "labels": ["Label"],
+          "properties": [
+            {"source_field": "id", "target_property": "id"}
+          ],
+          "schema": {
+              "key_constraints": [{
+                 "name": "a-key-constraint",
+                 "label": "Label",
+                 "properties": ["id"]
+              }]
+          }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": "a-node-target",
+            "properties": [
+                {"source_field": "id", "target_property": "property1"}
+            ],
+            "schema": {
+                "unique_constraints": [
+                    {"name": "a unique constraint", "properties": ["property1"]},
+                    {"name": "another unique constraint", "properties": ["property1"]}
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_unique_constraints_are_duplicated.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_unique_constraints_are_duplicated.yaml
@@ -1,0 +1,39 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: a-key-constraint
+        label: Label
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target
+    properties:
+    - source_field: id
+      target_property: property1
+    schema:
+      unique_constraints:
+      - name: a unique constraint
+        properties:
+        - property1
+      - name: another unique constraint
+        properties:
+        - property1


### PR DESCRIPTION
This pull request introduces a new validator, `NoDuplicatedSchemaDefinitionValidator`, which detects duplicate schema definitions (such as constraints or indexes with different names but identical definitions) in import specifications. It also refactors several existing validators to depend on this new validator and improves their redundancy detection logic for more precise validation.

These changes improve the accuracy of schema validation by ensuring that duplicate definitions are reported clearly and that redundancy checks only flag true overlaps between different constraint/index types.