### PR TITLE
fix: skip dependent validators entirely when a required validator fails

### DIFF
--- a/core/src/main/java/org/neo4j/importer/v1/validation/SpecificationValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/SpecificationValidator.java
@@ -62,12 +62,17 @@ public interface SpecificationValidator {
 
     /**
      * Declares validators whose validation must be successful before
-     * this validator can report errors and warnings.
-     * In other words, if any of the validation of the returned validators do not pass,
-     * this validator's implementation of {@link SpecificationValidator#report(Builder)} will not be called.
-     * It is however possible that this validator visitXxx methods are called regardless.
+     * this validator can be run.
+     * Validators are evaluated one at a time, in an order where every required validator is fully evaluated (all its
+     * visitXxx methods and its {@link SpecificationValidator#report(Builder)}) before the validators that require it.
+     * If any of the returned validators fails, this validator is skipped <strong>entirely</strong>: none of its
+     * visitXxx methods are called and its {@link SpecificationValidator#report(Builder)} is not called either.
+     * <br>
+     * As a consequence, whenever this validator's methods are invoked, all of its required validators are guaranteed to
+     * have passed. Implementations may therefore rely on the guarantees enforced by their required validators and skip
+     * defensively re-checking them.
      *
-     * @return the set of validator implementations whose validation must pass before this validator reports anything
+     * @return the set of validator implementations whose validation must pass before this validator is run
      */
     default Set<Class<? extends SpecificationValidator>> requires() {
         return Set.of();

--- a/core/src/main/java/org/neo4j/importer/v1/validation/SpecificationValidators.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/SpecificationValidators.java
@@ -38,7 +38,7 @@ public class SpecificationValidators {
     }
 
     public static SpecificationValidators of(List<SpecificationValidator> validators) {
-        return new SpecificationValidators(runTopogicalSort(validators));
+        return new SpecificationValidators(runTopologicalSort(validators));
     }
 
     public static SpecificationValidators of(SpecificationValidator validator) {
@@ -46,49 +46,21 @@ public class SpecificationValidators {
     }
 
     public void validate(ImportSpecification spec) throws SpecificationException {
-        validators.forEach(validator -> validator.visitConfiguration(spec.getConfiguration()));
-        var sources = spec.getSources();
-        for (int i = 0; i < sources.size(); i++) {
-            final int index = i;
-            validators.forEach(validator -> validator.visitSource(index, sources.get(index)));
-        }
-        var targets = spec.getTargets();
-        var nodeTargets = targets.getNodes();
-        for (int i = 0; i < nodeTargets.size(); i++) {
-            final int index = i;
-            validators.forEach(validator -> validator.visitNodeTarget(index, nodeTargets.get(index)));
-        }
-        var relationshipTargets = targets.getRelationships();
-        for (int i = 0; i < relationshipTargets.size(); i++) {
-            final int index = i;
-            validators.forEach(validator -> validator.visitRelationshipTarget(index, relationshipTargets.get(index)));
-        }
-        var queryTargets = targets.getCustomQueries();
-        for (int i = 0; i < queryTargets.size(); i++) {
-            final int index = i;
-            validators.forEach(validator -> validator.visitCustomQueryTarget(index, queryTargets.get(index)));
-        }
-        var actions = spec.getActions();
-        for (int i = 0; i < actions.size(); i++) {
-            final int index = i;
-            validators.forEach(validator -> validator.visitAction(index, actions.get(index)));
-        }
-
-        Set<Class<? extends SpecificationValidator>> failedValidations = new HashSet<>(validators.size());
         Map<Class<? extends SpecificationValidator>, SpecificationValidator> validatorsPerClass =
                 validators.stream().collect(toMap(SpecificationValidator::getClass, Function.identity()));
+        Set<Class<? extends SpecificationValidator>> failedValidations = new HashSet<>(validators.size());
         var builder = SpecificationValidationResult.builder();
-        validators.forEach(validator -> {
-            for (Class<? extends SpecificationValidator> dependent :
-                    resolveTransitiveRequires(validator, validatorsPerClass)) {
-                if (failedValidations.contains(dependent)) {
-                    return;
-                }
+
+        for (SpecificationValidator validator : validators) {
+            if (hasFailedRequirement(validator, validatorsPerClass, failedValidations)) {
+                continue;
             }
+            visitAll(validator, spec);
             if (validator.report(builder)) {
                 failedValidations.add(validator.getClass());
             }
-        });
+        }
+
         SpecificationValidationResult result = builder.build();
         if (!result.passes()) {
             throw new InvalidSpecificationException(result);
@@ -100,7 +72,7 @@ public class SpecificationValidators {
         return validators;
     }
 
-    private static List<SpecificationValidator> runTopogicalSort(List<SpecificationValidator> validators) {
+    private static List<SpecificationValidator> runTopologicalSort(List<SpecificationValidator> validators) {
         var validatorCatalog = new HashMap<Class<? extends SpecificationValidator>, SpecificationValidator>();
         var validatorGraph =
                 new HashMap<Class<? extends SpecificationValidator>, Set<Class<? extends SpecificationValidator>>>();
@@ -122,10 +94,58 @@ public class SpecificationValidators {
         stack.addAll(dependencyClasses);
         while (!stack.isEmpty()) {
             var dependencyClass = stack.pop();
-            result.add(dependencyClass);
+            if (!result.add(dependencyClass)) {
+                // already processed this requirement, do not expand it again
+                continue;
+            }
             var dependency = dependenciesPerClass.get(dependencyClass);
-            stack.addAll(dependency.requires());
+            if (dependency != null) {
+                // the dependency may be absent if a validator requires another one that was not provided
+                stack.addAll(dependency.requires());
+            }
         }
         return result;
+    }
+
+    private static boolean hasFailedRequirement(
+            SpecificationValidator validator,
+            Map<Class<? extends SpecificationValidator>, SpecificationValidator> dependenciesPerClass,
+            Set<Class<? extends SpecificationValidator>> failedValidations) {
+        for (Class<? extends SpecificationValidator> requirement :
+                resolveTransitiveRequires(validator, dependenciesPerClass)) {
+            if (failedValidations.contains(requirement)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void visitAll(SpecificationValidator validator, ImportSpecification spec) {
+        validator.visitConfiguration(spec.getConfiguration());
+        var sources = spec.getSources();
+        for (int i = 0; i < sources.size(); i++) {
+            validator.visitSource(i, sources.get(i));
+        }
+
+        var targets = spec.getTargets();
+        var nodeTargets = targets.getNodes();
+        for (int i = 0; i < nodeTargets.size(); i++) {
+            validator.visitNodeTarget(i, nodeTargets.get(i));
+        }
+
+        var relationshipTargets = targets.getRelationships();
+        for (int i = 0; i < relationshipTargets.size(); i++) {
+            validator.visitRelationshipTarget(i, relationshipTargets.get(i));
+        }
+
+        var queryTargets = targets.getCustomQueries();
+        for (int i = 0; i < queryTargets.size(); i++) {
+            validator.visitCustomQueryTarget(i, queryTargets.get(i));
+        }
+
+        var actions = spec.getActions();
+        for (int i = 0; i < actions.size(); i++) {
+            validator.visitAction(i, actions.get(i));
+        }
     }
 }

--- a/core/src/test/java/org/neo4j/importer/v1/validation/SpecificationValidatorsTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/validation/SpecificationValidatorsTest.java
@@ -22,8 +22,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.neo4j.importer.v1.Configuration;
 import org.neo4j.importer.v1.ImportSpecification;
 import org.neo4j.importer.v1.sources.BigQuerySource;
+import org.neo4j.importer.v1.sources.Source;
 import org.neo4j.importer.v1.targets.CustomQueryTarget;
 import org.neo4j.importer.v1.targets.Targets;
 import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
@@ -125,6 +127,103 @@ class SpecificationValidatorsTest {
                         + "=== Errors ===\n"
                         + "\t- [C/code][C/path] C/error message\n"
                         + "===============================================================================");
+    }
+
+    @Test
+    void reports_validation_failure_of_dependent_when_its_dependency_passes() {
+        // A requires C; C passes, so A is run and its own failure must be reported
+        var validatorA = new A(true);
+        var validatorC = new C(false);
+
+        var wrapper = SpecificationValidators.of(List.of(validatorA, validatorC));
+
+        assertThatThrownBy(() -> wrapper.validate(aSpec()))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessage("Import specification is invalid, see report below:\n"
+                        + "===============================================================================\n"
+                        + "Summary\n"
+                        + "===============================================================================\n"
+                        + "\t- 1 error(s)\n"
+                        + "\t- 0 warning(s)\n"
+                        + "\n"
+                        + "=== Errors ===\n"
+                        + "\t- [A/code][A/path] A/error message\n"
+                        + "===============================================================================");
+    }
+
+    @Test
+    void reports_validation_failure_of_deep_dependent_when_all_its_dependencies_pass() {
+        // C <- A <- B ; C and A pass, so B is run and its own failure must be reported
+        var validatorA = new A(false);
+        var validatorB = new B(true);
+        var validatorC = new C(false);
+
+        var wrapper = SpecificationValidators.of(List.of(validatorA, validatorC, validatorB));
+
+        assertThatThrownBy(() -> wrapper.validate(aSpec()))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessage("Import specification is invalid, see report below:\n"
+                        + "===============================================================================\n"
+                        + "Summary\n"
+                        + "===============================================================================\n"
+                        + "\t- 1 error(s)\n"
+                        + "\t- 0 warning(s)\n"
+                        + "\n"
+                        + "=== Errors ===\n"
+                        + "\t- [B/code][B/path] B/error message\n"
+                        + "===============================================================================");
+    }
+
+    @Test
+    void skips_whole_dependency_chain_when_the_root_dependency_fails() {
+        // C <- A <- B <- D ; C fails, so A, B and D are all skipped and only C's error is reported
+        var validatorA = new A();
+        var validatorB = new B();
+        var validatorC = new C(true);
+        var validatorD = new D();
+
+        var wrapper = SpecificationValidators.of(List.of(validatorA, validatorB, validatorC, validatorD));
+
+        assertThatThrownBy(() -> wrapper.validate(aSpec()))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessage("Import specification is invalid, see report below:\n"
+                        + "===============================================================================\n"
+                        + "Summary\n"
+                        + "===============================================================================\n"
+                        + "\t- 1 error(s)\n"
+                        + "\t- 0 warning(s)\n"
+                        + "\n"
+                        + "=== Errors ===\n"
+                        + "\t- [C/code][C/path] C/error message\n"
+                        + "===============================================================================");
+    }
+
+    @Test
+    void skips_dependent_entirely_when_requirement_fails() {
+        var requirement = new G(true);
+        var dependent = new H();
+
+        // passed in the "wrong" order on purpose: topological sort must run the requirement first
+        var wrapper = SpecificationValidators.of(List.of(dependent, requirement));
+
+        assertThatThrownBy(() -> wrapper.validate(aSpec()))
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContaining("[FAIL/code][FAIL/path] FAIL/error message");
+        assertThat(dependent.visited).isFalse();
+        assertThat(dependent.reported).isFalse();
+    }
+
+    @Test
+    void runs_dependent_when_requirement_passes() throws SpecificationException {
+        var requirement = new G(false);
+        var dependent = new H();
+
+        var wrapper = SpecificationValidators.of(List.of(dependent, requirement));
+
+        wrapper.validate(aSpec());
+
+        assertThat(dependent.visited).isTrue();
+        assertThat(dependent.reported).isTrue();
     }
 
     static class A implements SpecificationValidator {
@@ -266,6 +365,66 @@ class SpecificationValidatorsTest {
         @Override
         public String toString() {
             return "F";
+        }
+    }
+
+    static class G implements SpecificationValidator {
+
+        private final boolean reportsError;
+
+        public G(boolean reportsError) {
+            this.reportsError = reportsError;
+        }
+
+        @Override
+        public boolean report(Builder builder) {
+            if (reportsError) {
+                builder.addError("FAIL/path", "FAIL/code", "FAIL/error message");
+            }
+            return reportsError;
+        }
+
+        @Override
+        public String toString() {
+            return "FailableValidator";
+        }
+    }
+
+    // Requires G validator and records whether any of its methods ran.
+    static class H implements SpecificationValidator {
+
+        private boolean visited;
+        private boolean reported;
+
+        @Override
+        public Set<Class<? extends SpecificationValidator>> requires() {
+            return Set.of(G.class);
+        }
+
+        @Override
+        public void visitConfiguration(Configuration configuration) {
+            visited = true;
+        }
+
+        @Override
+        public void visitSource(int index, Source source) {
+            visited = true;
+        }
+
+        @Override
+        public void visitCustomQueryTarget(int index, CustomQueryTarget target) {
+            visited = true;
+        }
+
+        @Override
+        public boolean report(Builder builder) {
+            reported = true;
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "RecordingDependent";
         }
     }
 


### PR DESCRIPTION
Improves the validation:
Previously, "B requires A" only prevented B's `report()` from running when A failed — B's `visitXxx` methods had already run over the entire spec. This was   counter-intuitive, did wasted work as the validator set grows, and forced dependents to defensively tolerate invalid input that their required validators were supposed to reject.  

 **Before — element-major (phase-first) loop**                                                                                                                                                                                    
  - `validate()` looped elements on the outside, validators on the inside ("for each element, call every validator"), so all validators advanced together one phase at a time (config → sources → nodes → …).                                                                                                                                                     
                                                                                                                                                                                                                                   
  **After — validator-major loop**                                                                                                                                                                                                 
  - `validate()` now loops validators on the outside ("for each validator, run all of its visits, then its `report()`"), iterating in **topological order** so every required validator is fully evaluated before the validators that require it.                                                                                                                                                   
  - Because each required validator is fully evaluated (all visits **and** `report()`) before its dependents start, a dependent's verdict-blocking requirement is known  up front: a validator whose (transitive) requirement has failed is skipped .

additional changes:  null-safety, fix typo in method name        