### PR TITLE
fix: remove wrong property mention in keyless rel node validator

### DIFF
--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoKeylessRelationshipNodeValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoKeylessRelationshipNodeValidator.java
@@ -56,15 +56,13 @@ public class NoKeylessRelationshipNodeValidator implements SpecificationValidato
         if (keylessNodes.contains(startNode)) {
             errorMessages.put(
                     String.format("$.targets.relationships[%d].start_node_reference", index),
-                    String.format(
-                            "Node %s must define a key or unique constraint for property id, none found", startNode));
+                    String.format("Node %s must define a key or unique constraint, none found", startNode));
         }
         var endNode = target.getEndNodeReference().getName();
         if (keylessNodes.contains(endNode)) {
             errorMessages.put(
                     String.format("$.targets.relationships[%d].end_node_reference", index),
-                    String.format(
-                            "Node %s must define a key or unique constraint for property id, none found", endNode));
+                    String.format("Node %s must define a key or unique constraint, none found", endNode));
         }
     }
 

--- a/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -1807,8 +1807,8 @@ class ImportSpecificationDeserializerTest {
                 .isInstanceOf(InvalidSpecificationException.class)
                 .hasMessageContainingAll(
                         "0 warning(s)",
-                        "[$.targets.relationships[0].start_node_reference] Node a-node-target must define a key or unique constraint for property id, none found",
-                        "[$.targets.relationships[0].end_node_reference] Node a-node-target must define a key or unique constraint for property id, none found");
+                        "[$.targets.relationships[0].start_node_reference] Node a-node-target must define a key or unique constraint, none found",
+                        "[$.targets.relationships[0].end_node_reference] Node a-node-target must define a key or unique constraint, none found");
     }
 
     @ParameterizedTest
@@ -1825,8 +1825,8 @@ class ImportSpecificationDeserializerTest {
                 .hasMessageContainingAll(
                         "2 error(s)",
                         "0 warning(s)",
-                        "[$.targets.relationships[0].start_node_reference] Node a-node-target must define a key or unique constraint for property id, none found",
-                        "[$.targets.relationships[0].end_node_reference] Node a-node-target must define a key or unique constraint for property id, none found");
+                        "[$.targets.relationships[0].start_node_reference] Node a-node-target must define a key or unique constraint, none found",
+                        "[$.targets.relationships[0].end_node_reference] Node a-node-target must define a key or unique constraint, none found");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
There is no specific property involved in this validator.