### PR TITLE
feat: restrict node references to a single key/unique constraint

### DIFF
--- a/core/src/main/java/org/neo4j/importer/v1/pipeline/ImportPipeline.java
+++ b/core/src/main/java/org/neo4j/importer/v1/pipeline/ImportPipeline.java
@@ -365,9 +365,9 @@ public class ImportPipeline implements Iterable<ImportStep>, Serializable {
     }
 
     // a node target may define several key (or unique) constraints. When a relationship references such a node, its
-    // key mappings pick the correct constraints by retaining only the constraints fully covered by the referenced
-    // properties so that the node lookup matches on the referenced key alone rather than on the union of every key
-    // constraint.
+    // key mappings pick the correct constraint by retaining only the constraint whose properties exactly match the
+    // referenced properties so that the node lookup matches on the referenced key alone rather than on the union of
+    // every key constraint.
     private static NodeSchema restrictSchemaToReferencedKey(NodeSchema schema, List<KeyMapping> keyMappings) {
         if (schema == null) {
             return null;
@@ -375,10 +375,10 @@ public class ImportPipeline implements Iterable<ImportStep>, Serializable {
         var referencedProperties =
                 keyMappings.stream().map(KeyMapping::getNodeProperty).collect(Collectors.toSet());
         List<NodeKeyConstraint> keyConstraints = schema.getKeyConstraints().stream()
-                .filter(constraint -> referencedProperties.containsAll(constraint.getProperties()))
+                .filter(constraint -> referencedProperties.equals(Set.copyOf(constraint.getProperties())))
                 .collect(Collectors.toList());
         List<NodeUniqueConstraint> uniqueConstraints = schema.getUniqueConstraints().stream()
-                .filter(constraint -> referencedProperties.containsAll(constraint.getProperties()))
+                .filter(constraint -> referencedProperties.equals(Set.copyOf(constraint.getProperties())))
                 .collect(Collectors.toList());
         return new NodeSchema(
                 schema.getTypeConstraints(),

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/ExactlyOneNodeReferenceKeyMatchValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/ExactlyOneNodeReferenceKeyMatchValidator.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.importer.v1.validation.plugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.targets.KeyMapping;
+import org.neo4j.importer.v1.targets.NodeKeyConstraint;
+import org.neo4j.importer.v1.targets.NodeReference;
+import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.NodeUniqueConstraint;
+import org.neo4j.importer.v1.targets.RelationshipTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class ExactlyOneNodeReferenceKeyMatchValidator implements SpecificationValidator {
+
+    private static final String ERROR_CODE = "EONR-001";
+
+    private final Map<String, List<LookupConstraint>> possibleLookups = new HashMap<>();
+
+    private final Map<String, String> invalidKeyMappings = new LinkedHashMap<>();
+
+    @Override
+    public Set<Class<? extends SpecificationValidator>> requires() {
+        return Set.of(
+                NoDanglingKeyInNodeReferenceKeyMappingsValidator.class,
+                NoIncompleteNodeReferenceKeyMatchValidator.class);
+    }
+
+    @Override
+    public void visitNodeTarget(int index, NodeTarget nodeTarget) {
+        var schema = nodeTarget.getSchema();
+        var keyConstraints = schema.getKeyConstraints();
+        for (int i = 0; i < keyConstraints.size(); i++) {
+            possibleLookups
+                    .computeIfAbsent(nodeTarget.getName(), (name) -> new ArrayList<>())
+                    .add(LookupConstraint.key(
+                            keyConstraints.get(i),
+                            String.format("$.targets.nodes[%d].schema.key_constraints[%d]", index, i)));
+        }
+        var uniqueConstraints = schema.getUniqueConstraints();
+        for (int i = 0; i < uniqueConstraints.size(); i++) {
+            possibleLookups
+                    .computeIfAbsent(nodeTarget.getName(), (name) -> new ArrayList<>())
+                    .add(LookupConstraint.unique(
+                            uniqueConstraints.get(i),
+                            String.format("$.targets.nodes[%d].schema.unique_constraints[%d]", index, i)));
+        }
+    }
+
+    @Override
+    public void visitRelationshipTarget(int index, RelationshipTarget relationshipTarget) {
+        visitKeyMappings(
+                String.format("$.targets.relationships[%d].start_node_reference.key_mappings", index),
+                relationshipTarget.getStartNodeReference());
+        visitKeyMappings(
+                String.format("$.targets.relationships[%d].end_node_reference.key_mappings", index),
+                relationshipTarget.getEndNodeReference());
+    }
+
+    @Override
+    public boolean report(Builder builder) {
+        invalidKeyMappings.forEach((path, message) -> {
+            builder.addError(path, ERROR_CODE, message);
+        });
+        return !invalidKeyMappings.isEmpty();
+    }
+
+    private void visitKeyMappings(String path, NodeReference nodeReference) {
+        var keyMappings = nodeReference.getKeyMappings();
+        if (keyMappings.isEmpty()) {
+            return;
+        }
+        var lookupConstraints = possibleLookups.get(nodeReference.getName());
+        if (lookupConstraints == null) {
+            return;
+        }
+
+        var mappedProperties =
+                keyMappings.stream().map(KeyMapping::getNodeProperty).collect(Collectors.toSet());
+        var matchedConstraints = lookupConstraints.stream()
+                .filter(lookup -> mappedProperties.equals(lookup.getProperties()))
+                .collect(Collectors.toList());
+        if (matchedConstraints.size() == 1) {
+            return;
+        }
+
+        var error = String.format(
+                "Invalid key mapping for node reference '%s'. Expected it to exactly match 1 node target key or unique constraint, but it exactly matches %s%s",
+                nodeReference.getName(),
+                formatConstraintCount(matchedConstraints.size()),
+                describeMatchedConstraintPaths(matchedConstraints));
+        invalidKeyMappings.put(path, error);
+    }
+
+    private static String formatConstraintCount(int count) {
+        var constraint = count == 0 ? "constraint" : "constraints";
+        return String.format("%d node target key or unique %s", count, constraint);
+    }
+
+    private static String describeMatchedConstraintPaths(List<LookupConstraint> matchedConstraints) {
+        if (matchedConstraints.isEmpty()) {
+            return ".";
+        }
+        var matchedConstraintPaths =
+                matchedConstraints.stream().map(LookupConstraint::getPath).collect(Collectors.joining("\n\t"));
+        return String.format(":\n\t%s", matchedConstraintPaths);
+    }
+
+    private static final class LookupConstraint {
+
+        private final Set<String> properties;
+        private final String path;
+
+        private LookupConstraint(List<String> properties, String path) {
+            this.properties = Set.copyOf(properties);
+            this.path = path;
+        }
+
+        static LookupConstraint key(NodeKeyConstraint constraint, String path) {
+            return new LookupConstraint(constraint.getProperties(), path);
+        }
+
+        static LookupConstraint unique(NodeUniqueConstraint constraint, String path) {
+            return new LookupConstraint(constraint.getProperties(), path);
+        }
+
+        Set<String> getProperties() {
+            return properties;
+        }
+
+        String getPath() {
+            return path;
+        }
+    }
+}

--- a/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoIncompleteNodeReferenceKeyMatchValidator.java
+++ b/core/src/main/java/org/neo4j/importer/v1/validation/plugin/NoIncompleteNodeReferenceKeyMatchValidator.java
@@ -17,16 +17,13 @@
 package org.neo4j.importer.v1.validation.plugin;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.neo4j.importer.v1.targets.KeyMapping;
 import org.neo4j.importer.v1.targets.NodeKeyConstraint;
 import org.neo4j.importer.v1.targets.NodeReference;
@@ -86,62 +83,47 @@ public class NoIncompleteNodeReferenceKeyMatchValidator implements Specification
             // keyless node, ignoring (another upstream validator takes care of this)
             return;
         }
-        var matches = lookupProperties.stream()
-                .flatMap(lookup -> indexByProperty(new Match(lookup), lookup.getProperties()))
-                .collect(Collectors.toMap(
-                        Entry::getKey, entry -> List.of(entry.getValue()), (matches1, matches2) -> Stream.concat(
-                                        matches1.stream(), matches2.stream())
-                                .collect(Collectors.toList())));
-        keyMappings.forEach(key -> trackMatches(key, matches));
-        var matchedProperties = matches.values().stream()
-                .flatMap(Collection::stream)
-                .filter(Match::fullyMatches)
-                .flatMap(match -> match.getLookup().getProperties().stream())
+        var mappedProperties =
+                keyMappings.stream().map(KeyMapping::getNodeProperty).collect(Collectors.toSet());
+        var matchedProperties = lookupProperties.stream()
+                .filter(lookup -> mappedProperties.containsAll(lookup.getProperties()))
+                .flatMap(lookup -> lookup.getProperties().stream())
                 .collect(Collectors.toSet());
         for (int i = 0; i < keyMappings.size(); i++) {
             var mappedKey = keyMappings.get(i).getNodeProperty();
             if (!matchedProperties.contains(mappedKey)) {
-                var maybeClosestMatch = matches.values().stream()
-                        .flatMap(Collection::stream)
-                        .filter(match -> match.includes(mappedKey))
-                        .max(NoIncompleteNodeReferenceKeyMatchValidator::sortMatches);
-                var mappingPath = String.format("%s.key_mappings[%d]", path, i);
+                var maybeClosestMatch = lookupProperties.stream()
+                        .filter(lookup -> lookup.includes(mappedKey))
+                        .max((lookup1, lookup2) -> sortLookups(lookup1, lookup2, mappedProperties));
+                var mappingPath = String.format("%s[%d]", path, i);
                 if (maybeClosestMatch.isEmpty()) {
                     // prop is invalid or not a key/not unique, ignoring (another upstream validator takes care of this)
                     return;
                 }
                 var closestMatch = maybeClosestMatch.get();
-                var missingKeys = closestMatch.getLookup().getProperties().stream()
-                        .filter(property -> !property.equals(mappedKey))
+                var missingKeys = closestMatch.getProperties().stream()
+                        .filter(property -> !mappedProperties.contains(property))
                         .collect(Collectors.toList());
                 var error = String.format(
                         "Insufficient key mapping for node reference '%s'. Please also map ['%s'] alongside '%s' to fully match the node target's %s constraint '%s'",
                         nodeReference.getName(),
                         String.join("', '", missingKeys),
                         mappedKey,
-                        closestMatch.getLookupType().toString().toLowerCase(Locale.ROOT),
+                        closestMatch.getType().toString().toLowerCase(Locale.ROOT),
                         closestMatch.getConstraintName());
                 incompleteKeyMappings.put(mappingPath, error);
             }
         }
     }
 
-    private static Stream<Entry<String, Match>> indexByProperty(Match initialMatch, List<String> properties) {
-        return properties.stream().map(property -> Map.entry(property, initialMatch));
-    }
-
-    private static void trackMatches(KeyMapping key, Map<String, List<Match>> allMatches) {
-        allMatches.getOrDefault(key.getNodeProperty(), List.of()).forEach(Match::incrementMatch);
-    }
-
-    private static int sortMatches(Match match1, Match match2) {
-        var count1 = match1.getMatchCount();
-        var count2 = match2.getMatchCount();
+    private static int sortLookups(LookupProperties lookup1, LookupProperties lookup2, Set<String> mappedProperties) {
+        var count1 = lookup1.countMatches(mappedProperties);
+        var count2 = lookup2.countMatches(mappedProperties);
         if (count1 == count2) {
             // more specific key/unique definitions win (i.e., key/unique defs with more properties)
             // this is because such definitions are likely to offer a lower cardinality and a faster lookup
             // when leveraged in queries
-            return match1.getPropertyCount() - match2.getPropertyCount();
+            return lookup1.getPropertyCount() - lookup2.getPropertyCount();
         }
         return count1 - count2;
     }
@@ -177,47 +159,17 @@ public class NoIncompleteNodeReferenceKeyMatchValidator implements Specification
         public String getConstraintName() {
             return constraintName;
         }
-    }
-
-    private static class Match {
-
-        private final LookupProperties lookup;
-        private int matchCount;
-
-        private Match(LookupProperties lookupProperties) {
-            this.lookup = lookupProperties;
-        }
-
-        public LookupProperties getLookup() {
-            return lookup;
-        }
-
-        public void incrementMatch() {
-            matchCount++;
-        }
-
-        public boolean fullyMatches() {
-            return matchCount == lookup.getProperties().size();
-        }
 
         public boolean includes(String property) {
-            return lookup.getProperties().contains(property);
+            return properties.contains(property);
         }
 
-        public int getMatchCount() {
-            return matchCount;
+        public int countMatches(Set<String> mappedProperties) {
+            return (int) properties.stream().filter(mappedProperties::contains).count();
         }
 
         public int getPropertyCount() {
-            return lookup.getProperties().size();
-        }
-
-        public LookupType getLookupType() {
-            return lookup.getType();
-        }
-
-        public String getConstraintName() {
-            return lookup.getConstraintName();
+            return properties.size();
         }
     }
 

--- a/core/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/core/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -1,5 +1,6 @@
 # keep this alphabetically sorted
 org.neo4j.importer.v1.validation.plugin.AtLeastOneActiveTargetValidator
+org.neo4j.importer.v1.validation.plugin.ExactlyOneNodeReferenceKeyMatchValidator
 org.neo4j.importer.v1.validation.plugin.NoBlankCypherActionQueryValidator
 org.neo4j.importer.v1.validation.plugin.NoByteArrayPropertyInTypeConstraintValidator
 org.neo4j.importer.v1.validation.plugin.NoDanglingActiveNodeReferenceValidator

--- a/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -1744,6 +1744,57 @@ class ImportSpecificationDeserializerTest {
 
     @ParameterizedTest
     @EnumSource(SpecFormat.class)
+    void fails_if_relationship_start_node_reference_partially_matches_node_key_constraint(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[NINR-001][$.targets.relationships[0].start_node_reference.key_mappings[0]] Insufficient key mapping for node reference 'a-node-target'. Please also map ['tenant_id'] alongside 'id' to fully match the node target's key constraint 'a-key-constraint'");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_relationship_end_node_reference_partially_matches_node_unique_constraint(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[NINR-001][$.targets.relationships[0].end_node_reference.key_mappings[0]] Insufficient key mapping for node reference 'a-node-target'. Please also map ['tenant_id'] alongside 'id' to fully match the node target's unique constraint 'a-unique-constraint'");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void displays_closest_match_with_largest_number_of_properties_when_validation_fails(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[NINR-001][$.targets.relationships[0].start_node_reference.key_mappings[0]] Insufficient key mapping for node reference 'a-node'. Please also map ['f', 'g'] alongside 'a' to fully match the node target's unique constraint 'unique-a-f-g'");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
     void does_not_fail_if_relationship_start_node_reference_refers_to_node_key_property(
             SpecFormat format, TestInfo testInfo) {
 

--- a/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/ImportSpecificationDeserializerTest.java
@@ -1795,7 +1795,54 @@ class ImportSpecificationDeserializerTest {
 
     @ParameterizedTest
     @EnumSource(SpecFormat.class)
+    void fails_if_relationship_start_node_reference_matches_no_exact_node_key_or_unique_constraint(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[EONR-001][$.targets.relationships[0].start_node_reference.key_mappings] Invalid key mapping for node reference 'a-node-target'. Expected it to exactly match 1 node target key or unique constraint, but it exactly matches 0 node target key or unique constraint.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void fails_if_relationship_start_node_reference_exactly_matches_several_node_key_or_unique_constraints(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatThrownBy(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .isInstanceOf(InvalidSpecificationException.class)
+                .hasMessageContainingAll(
+                        "1 error(s)",
+                        "0 warning(s)",
+                        "[EONR-001][$.targets.relationships[0].start_node_reference.key_mappings] Invalid key mapping for node reference 'a-node-target'. Expected it to exactly match 1 node target key or unique constraint, but it exactly matches 2 node target key or unique constraints:\n\t$.targets.nodes[0].schema.key_constraints[0]\n\t$.targets.nodes[0].schema.key_constraints[1]");
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
     void does_not_fail_if_relationship_start_node_reference_refers_to_node_key_property(
+            SpecFormat format, TestInfo testInfo) {
+
+        assertThatCode(() -> {
+                    try (var reader = specReader(format, testInfo)) {
+                        deserialize(reader);
+                    }
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(SpecFormat.class)
+    void does_not_fail_if_relationship_node_references_have_no_key_mapping_when_several_constraints_exist(
             SpecFormat format, TestInfo testInfo) {
 
         assertThatCode(() -> {

--- a/core/src/test/java/org/neo4j/importer/v1/pipeline/ImportPipelineTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/pipeline/ImportPipelineTest.java
@@ -35,6 +35,7 @@ import org.neo4j.importer.v1.targets.NodeMatchMode;
 import org.neo4j.importer.v1.targets.NodeReference;
 import org.neo4j.importer.v1.targets.NodeSchema;
 import org.neo4j.importer.v1.targets.NodeTarget;
+import org.neo4j.importer.v1.targets.NodeUniqueConstraint;
 import org.neo4j.importer.v1.targets.PropertyMapping;
 import org.neo4j.importer.v1.targets.PropertyType;
 import org.neo4j.importer.v1.targets.RelationshipTarget;
@@ -298,6 +299,69 @@ class ImportPipelineTest {
                 .containsExactly(
                         new PropertyMapping("known_first", "firstName", PropertyType.STRING),
                         new PropertyMapping("known_last", "lastName", PropertyType.STRING));
+    }
+
+    @Test
+    void resolves_relationship_node_reference_to_exact_unique_constraint_when_key_constraint_is_subset() {
+        var idKey = new NodeKeyConstraint("person-id-key", "Person", List.of("id"), Map.of());
+        var tenantIdAndIdUnique = new NodeUniqueConstraint(
+                "person-tenant-id-and-id-unique", "Person", List.of("tenantId", "id"), Map.of());
+        var startRef = new NodeReference(
+                "person-nodes",
+                List.of(new KeyMapping("person_tenant_id", "tenantId"), new KeyMapping("person_id", "id")));
+        var spec = new ImportSpecification(
+                "a-version",
+                new HashMap<>(),
+                List.of(new DummySource("people"), new DummySource("orders")),
+                new Targets(
+                        List.of(new NodeTarget(
+                                true,
+                                "person-nodes",
+                                "people",
+                                List.of(),
+                                WriteMode.MERGE,
+                                (ObjectNode) null,
+                                List.of("Person"),
+                                List.of(
+                                        new PropertyMapping("tenant_id", "tenantId", PropertyType.STRING),
+                                        new PropertyMapping("id", "id", PropertyType.STRING)),
+                                new NodeSchema(
+                                        null,
+                                        List.of(idKey),
+                                        List.of(tenantIdAndIdUnique),
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null))),
+                        List.of(new RelationshipTarget(
+                                true,
+                                "ordered-by-relationships",
+                                "orders",
+                                List.of(),
+                                "ORDERED_BY",
+                                WriteMode.MERGE,
+                                NodeMatchMode.MATCH,
+                                (ObjectNode) null,
+                                startRef,
+                                new NodeReference("person-nodes"),
+                                List.of(),
+                                null)),
+                        List.of()),
+                List.of());
+
+        var pipeline = ImportPipeline.of(spec);
+
+        var relationships = stream(pipeline)
+                .filter(step -> step instanceof RelationshipTargetStep)
+                .map(step -> (RelationshipTargetStep) step)
+                .collect(Collectors.toList());
+        assertThat(relationships).hasSize(1);
+        assertThat(relationships.get(0).startNode().keyProperties())
+                .containsExactly(
+                        new PropertyMapping("person_tenant_id", "tenantId", PropertyType.STRING),
+                        new PropertyMapping("person_id", "id", PropertyType.STRING));
     }
 
     private static @NotNull NodeSchema schemaFor(NodeKeyConstraint keyConstraint) {

--- a/core/src/test/java/org/neo4j/importer/v1/validation/plugin/NoIncompleteNodeReferenceKeyMatchValidatorTest.java
+++ b/core/src/test/java/org/neo4j/importer/v1/validation/plugin/NoIncompleteNodeReferenceKeyMatchValidatorTest.java
@@ -30,7 +30,6 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -111,32 +110,6 @@ class NoIncompleteNodeReferenceKeyMatchValidatorTest {
                 return message.startsWith(expectedErrorMessage);
             });
         });
-    }
-
-    @Test
-    void displays_closest_match_with_largest_number_of_properties_when_validation_fails() {
-        var spec = importSpec(
-                node(
-                        "a-node",
-                        keyProperties(List.of("a", "c"), List.of("b")),
-                        uniqueProperties(List.of("a", "f", "g"))),
-                relationship(startNodeReference("a-node", List.of("a"))));
-        validator.visitNodeTarget(0, spec.getTargets().getNodes().get(0));
-        validator.visitRelationshipTarget(
-                0, spec.getTargets().getRelationships().get(0));
-        var reportBuilder = new Builder();
-
-        boolean result = validator.report(reportBuilder);
-        assertThat(result)
-                .overridingErrorMessage("expected an error message, but got none")
-                .isTrue();
-        var errorMessages = reportBuilder.build().getErrors().stream()
-                .map(SpecificationError::getMessage)
-                .collect(Collectors.toList());
-        assertThat(errorMessages).hasSize(1);
-        assertThat(errorMessages.get(0))
-                .startsWith(
-                        "Insufficient key mapping for node reference 'a-node'. Please also map ['f', 'g'] alongside 'a' to fully match the node target's unique constraint 'unique-constraint-");
     }
 
     private static Stream<Arguments> matching_property_combinations() {

--- a/core/src/test/resources/specs/import_specification_deserializer_test/displays_closest_match_with_largest_number_of_properties_when_validation_fails.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/displays_closest_match_with_largest_number_of_properties_when_validation_fails.json
@@ -1,0 +1,48 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node",
+            "source": "a-source",
+            "labels": ["ALabel"],
+            "properties": [
+                {"source_field": "a", "target_property": "a"},
+                {"source_field": "c", "target_property": "c"},
+                {"source_field": "b", "target_property": "b"},
+                {"source_field": "f", "target_property": "f"},
+                {"source_field": "g", "target_property": "g"}
+            ],
+            "schema": {
+                "key_constraints": [
+                    {"name": "key-a-c", "label": "ALabel", "properties": ["a", "c"]},
+                    {"name": "key-b", "label": "ALabel", "properties": ["b"]}
+                ],
+                "unique_constraints": [
+                    {"name": "unique-a-f-g", "label": "ALabel", "properties": ["a", "f", "g"]}
+                ]
+            }
+        }],
+        "relationships": [{
+            "name": "a-relationship",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": "create",
+            "start_node_reference": {
+                "name": "a-node",
+                "key_mappings": [
+                    {
+                        "source_field": "source_a",
+                        "node_property": "a"
+                    }
+                ]
+            },
+            "end_node_reference": "a-node"
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/displays_closest_match_with_largest_number_of_properties_when_validation_fails.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/displays_closest_match_with_largest_number_of_properties_when_validation_fails.yaml
@@ -1,0 +1,53 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node
+    source: a-source
+    labels:
+    - ALabel
+    properties:
+    - source_field: a
+      target_property: a
+    - source_field: c
+      target_property: c
+    - source_field: b
+      target_property: b
+    - source_field: f
+      target_property: f
+    - source_field: g
+      target_property: g
+    schema:
+      key_constraints:
+      - name: key-a-c
+        label: ALabel
+        properties:
+        - a
+        - c
+      - name: key-b
+        label: ALabel
+        properties:
+        - b
+      unique_constraints:
+      - name: unique-a-f-g
+        label: ALabel
+        properties:
+        - a
+        - f
+        - g
+  relationships:
+  - name: a-relationship
+    source: a-source
+    type: TYPE
+    write_mode: create
+    start_node_reference:
+      name: a-node
+      key_mappings:
+      - source_field: source_a
+        node_property: a
+    end_node_reference: a-node

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_node_references_have_no_key_mapping_when_several_constraints_exist.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_node_references_have_no_key_mapping_when_several_constraints_exist.json
@@ -1,0 +1,36 @@
+{
+  "version": "1",
+  "sources": [{
+    "name": "a-source",
+    "type": "jdbc",
+    "data_source": "a-data-source",
+    "sql": "SELECT id, email FROM my.table"
+  }],
+  "targets": {
+    "nodes": [{
+      "name": "a-node-target",
+      "source": "a-source",
+      "labels": ["Label"],
+      "properties": [
+        {"source_field": "id", "target_property": "id"},
+        {"source_field": "email", "target_property": "email"}
+      ],
+      "schema": {
+        "key_constraints": [
+          {"name": "id-key", "label": "Label", "properties": ["id"]}
+        ],
+        "unique_constraints": [
+          {"name": "email-unique", "label": "Label", "properties": ["email"]}
+        ]
+      }
+    }],
+    "relationships": [{
+      "name": "a-relationship-target",
+      "source": "a-source",
+      "type": "TYPE",
+      "write_mode": "create",
+      "start_node_reference": "a-node-target",
+      "end_node_reference": "a-node-target"
+    }]
+  }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_node_references_have_no_key_mapping_when_several_constraints_exist.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_node_references_have_no_key_mapping_when_several_constraints_exist.yaml
@@ -1,0 +1,36 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, email FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    - source_field: email
+      target_property: email
+    schema:
+      key_constraints:
+      - name: id-key
+        label: Label
+        properties:
+        - id
+      unique_constraints:
+      - name: email-unique
+        label: Label
+        properties:
+        - email
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    write_mode: create
+    start_node_reference: a-node-target
+    end_node_reference: a-node-target

--- a/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_longer_overlapping_key_constraint.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/does_not_fail_if_relationship_references_node_via_longer_overlapping_key_constraint.json
@@ -1,4 +1,3 @@
-
 {
     "version": "1",
     "sources": [{

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_end_node_reference_partially_matches_node_unique_constraint.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_end_node_reference_partially_matches_node_unique_constraint.json
@@ -1,0 +1,43 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"},
+                {"source_field": "tenant_id", "target_property": "tenant_id"}
+            ],
+            "schema": {
+                "unique_constraints": [{
+                    "name": "a-unique-constraint",
+                    "label": "Label",
+                    "properties": ["id", "tenant_id"]
+                }]
+            }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": "create",
+            "start_node_reference": "a-node-target",
+            "end_node_reference": {
+                "name": "a-node-target",
+                "key_mappings": [
+                    {
+                        "source_field": "source_id",
+                        "node_property": "id"
+                    }
+                ]
+            }
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_end_node_reference_partially_matches_node_unique_constraint.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_end_node_reference_partially_matches_node_unique_constraint.yaml
@@ -1,0 +1,36 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    - source_field: tenant_id
+      target_property: tenant_id
+    schema:
+      unique_constraints:
+      - name: a-unique-constraint
+        label: Label
+        properties:
+        - id
+        - tenant_id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    write_mode: create
+    start_node_reference: a-node-target
+    end_node_reference:
+      name: a-node-target
+      key_mappings:
+      - source_field: source_id
+        node_property: id

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_exactly_matches_several_node_key_or_unique_constraints.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_exactly_matches_several_node_key_or_unique_constraints.json
@@ -1,0 +1,38 @@
+{
+  "version": "1",
+  "sources": [{
+    "name": "a-source",
+    "type": "jdbc",
+    "data_source": "a-data-source",
+    "sql": "SELECT id FROM my.table"
+  }],
+  "targets": {
+    "nodes": [{
+      "name": "a-node-target",
+      "source": "a-source",
+      "labels": ["Person", "Employee"],
+      "properties": [
+        {"source_field": "id", "target_property": "id"}
+      ],
+      "schema": {
+        "key_constraints": [
+          {"name": "person-id-key", "label": "Person", "properties": ["id"]},
+          {"name": "employee-id-key", "label": "Employee", "properties": ["id"]}
+        ]
+      }
+    }],
+    "relationships": [{
+      "name": "a-relationship-target",
+      "source": "a-source",
+      "type": "TYPE",
+      "write_mode": "create",
+      "start_node_reference": {
+        "name": "a-node-target",
+        "key_mappings": [
+          {"source_field": "source_id", "node_property": "id"}
+        ]
+      },
+      "end_node_reference": "a-node-target"
+    }]
+  }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_exactly_matches_several_node_key_or_unique_constraints.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_exactly_matches_several_node_key_or_unique_constraints.yaml
@@ -1,0 +1,38 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Person
+    - Employee
+    properties:
+    - source_field: id
+      target_property: id
+    schema:
+      key_constraints:
+      - name: person-id-key
+        label: Person
+        properties:
+        - id
+      - name: employee-id-key
+        label: Employee
+        properties:
+        - id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    write_mode: create
+    start_node_reference:
+      name: a-node-target
+      key_mappings:
+      - source_field: source_id
+        node_property: id
+    end_node_reference: a-node-target

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_matches_no_exact_node_key_or_unique_constraint.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_matches_no_exact_node_key_or_unique_constraint.json
@@ -1,0 +1,42 @@
+{
+  "version": "1",
+  "sources": [{
+    "name": "a-source",
+    "type": "jdbc",
+    "data_source": "a-data-source",
+    "sql": "SELECT id, email FROM my.table"
+  }],
+  "targets": {
+    "nodes": [{
+      "name": "a-node-target",
+      "source": "a-source",
+      "labels": ["Label"],
+      "properties": [
+        {"source_field": "id", "target_property": "id"},
+        {"source_field": "email", "target_property": "email"}
+      ],
+      "schema": {
+        "key_constraints": [
+          {"name": "id-key", "label": "Label", "properties": ["id"]}
+        ],
+        "unique_constraints": [
+          {"name": "email-unique", "label": "Label", "properties": ["email"]}
+        ]
+      }
+    }],
+    "relationships": [{
+      "name": "a-relationship-target",
+      "source": "a-source",
+      "type": "TYPE",
+      "write_mode": "create",
+      "start_node_reference": {
+        "name": "a-node-target",
+        "key_mappings": [
+          {"source_field": "source_id", "node_property": "id"},
+          {"source_field": "source_email", "node_property": "email"}
+        ]
+      },
+      "end_node_reference": "a-node-target"
+    }]
+  }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_matches_no_exact_node_key_or_unique_constraint.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_matches_no_exact_node_key_or_unique_constraint.yaml
@@ -1,0 +1,42 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, email FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    - source_field: email
+      target_property: email
+    schema:
+      key_constraints:
+      - name: id-key
+        label: Label
+        properties:
+        - id
+      unique_constraints:
+      - name: email-unique
+        label: Label
+        properties:
+        - email
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    write_mode: create
+    start_node_reference:
+      name: a-node-target
+      key_mappings:
+      - source_field: source_id
+        node_property: id
+      - source_field: source_email
+        node_property: email
+    end_node_reference: a-node-target

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_partially_matches_node_key_constraint.json
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_partially_matches_node_key_constraint.json
@@ -1,0 +1,43 @@
+{
+    "version": "1",
+    "sources": [{
+        "name": "a-source",
+        "type": "jdbc",
+        "data_source": "a-data-source",
+        "sql": "SELECT id, name FROM my.table"
+    }],
+    "targets": {
+        "nodes": [{
+            "name": "a-node-target",
+            "source": "a-source",
+            "labels": ["Label"],
+            "properties": [
+                {"source_field": "id", "target_property": "id"},
+                {"source_field": "tenant_id", "target_property": "tenant_id"}
+            ],
+            "schema": {
+                "key_constraints": [{
+                    "name": "a-key-constraint",
+                    "label": "Label",
+                    "properties": ["id", "tenant_id"]
+                }]
+            }
+        }],
+        "relationships": [{
+            "name": "a-relationship-target",
+            "source": "a-source",
+            "type": "TYPE",
+            "write_mode": "create",
+            "start_node_reference": {
+                "name": "a-node-target",
+                "key_mappings": [
+                    {
+                        "source_field": "source_id",
+                        "node_property": "id"
+                    }
+                ]
+            },
+            "end_node_reference": "a-node-target"
+        }]
+    }
+}

--- a/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_partially_matches_node_key_constraint.yaml
+++ b/core/src/test/resources/specs/import_specification_deserializer_test/fails_if_relationship_start_node_reference_partially_matches_node_key_constraint.yaml
@@ -1,0 +1,36 @@
+---
+version: '1'
+sources:
+- name: a-source
+  type: jdbc
+  data_source: a-data-source
+  sql: SELECT id, name FROM my.table
+targets:
+  nodes:
+  - name: a-node-target
+    source: a-source
+    labels:
+    - Label
+    properties:
+    - source_field: id
+      target_property: id
+    - source_field: tenant_id
+      target_property: tenant_id
+    schema:
+      key_constraints:
+      - name: a-key-constraint
+        label: Label
+        properties:
+        - id
+        - tenant_id
+  relationships:
+  - name: a-relationship-target
+    source: a-source
+    type: TYPE
+    write_mode: create
+    start_node_reference:
+      name: a-node-target
+      key_mappings:
+      - source_field: source_id
+        node_property: id
+    end_node_reference: a-node-target


### PR DESCRIPTION
The existing validators allows key mappings to refer to more than
key or unique constraint of the corresponding node target.

This is not allowed anymore.

BREAKING CHANGE: a node reference key mappings cannot refer to
multiple key/unique constraints anymore.